### PR TITLE
fix: harden transcription and production chrome

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -457,6 +457,19 @@ h2 {
   margin-top: 24px;
 }
 
+.review-repo-choice {
+  display: grid;
+  gap: 16px;
+}
+
+.review-repo-choice ul {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
 .review-empty {
   max-width: 780px;
 }

--- a/apps/web/app/review/page.tsx
+++ b/apps/web/app/review/page.tsx
@@ -3,6 +3,10 @@ import { loadReviewQueue } from "../../lib/maintainer-review";
 import { readPageSessionRequest } from "../../lib/http-auth";
 import { getWebRuntime } from "../../lib/runtime";
 import { WebRequestRateLimitExceededError } from "../../lib/request-rate-limit";
+import {
+  listActiveMaintainerRepositories,
+  type ActiveMaintainerRepositoryV1,
+} from "../../lib/github-oauth-production";
 import { DemoMaintainerLogin } from "./demo-maintainer-login";
 
 export const dynamic = "force-dynamic";
@@ -30,7 +34,9 @@ export default async function ReviewQueuePage() {
           {app.config.DEMO_MODE ? (
             <DemoMaintainerLogin />
           ) : (
-            <GithubMaintainerLogin />
+            <GithubMaintainerLogin
+              repositories={await loadReviewLoginRepositories(app)}
+            />
           )}
         </section>
       </ReviewShell>
@@ -126,7 +132,9 @@ export default async function ReviewQueuePage() {
           {app.config.DEMO_MODE ? (
             <DemoMaintainerLogin />
           ) : (
-            <GithubMaintainerLogin />
+            <GithubMaintainerLogin
+              repositories={await loadReviewLoginRepositories(app)}
+            />
           )}
         </section>
       </ReviewShell>
@@ -134,15 +142,59 @@ export default async function ReviewQueuePage() {
   }
 }
 
-function GithubMaintainerLogin() {
+async function loadReviewLoginRepositories(
+  app: Awaited<ReturnType<typeof getWebRuntime>>,
+): Promise<readonly ActiveMaintainerRepositoryV1[]> {
+  try {
+    return await listActiveMaintainerRepositories(app.database.pool);
+  } catch {
+    return [];
+  }
+}
+
+function GithubMaintainerLogin({
+  repositories,
+}: {
+  repositories: readonly ActiveMaintainerRepositoryV1[];
+}) {
+  if (repositories.length === 0) {
+    return (
+      <p className="review-login">
+        Maintainer authorization is temporarily unavailable.
+      </p>
+    );
+  }
+  if (repositories.length === 1) {
+    return (
+      <a
+        className="button primary review-login"
+        href={reviewAuthorizationHref(repositories[0]!.id)}
+      >
+        Authorize with GitHub
+      </a>
+    );
+  }
   return (
-    <a
-      className="button primary"
-      href="/api/auth/github/start?returnTo=%2Freview"
-    >
-      Authorize with GitHub
-    </a>
+    <nav className="review-login review-repo-choice" aria-label="Choose repository">
+      <p>Choose the repository to review.</p>
+      <ul>
+        {repositories.map((repository) => (
+          <li key={repository.id}>
+            <a
+              className="button primary"
+              href={reviewAuthorizationHref(repository.id)}
+            >
+              Authorize {repository.owner}/{repository.name}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
   );
+}
+
+function reviewAuthorizationHref(repositoryId: string): string {
+  return `/api/auth/github/start?returnTo=${encodeURIComponent("/review")}&repositoryId=${encodeURIComponent(repositoryId)}`;
 }
 
 function ReviewShell({

--- a/apps/web/app/review/page.tsx
+++ b/apps/web/app/review/page.tsx
@@ -5,25 +5,53 @@ import { getWebRuntime } from "../../lib/runtime";
 import { WebRequestRateLimitExceededError } from "../../lib/request-rate-limit";
 import {
   listActiveMaintainerRepositories,
+  loadActiveMaintainerRepository,
   type ActiveMaintainerRepositoryV1,
 } from "../../lib/github-oauth-production";
 import { DemoMaintainerLogin } from "./demo-maintainer-login";
+import { z } from "zod";
 
 export const dynamic = "force-dynamic";
 
-export default async function ReviewQueuePage() {
+export default async function ReviewQueuePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ repositoryId?: string | string[] }>;
+}) {
   const app = await getWebRuntime();
+  const requestedRepository = await loadRequestedReviewRepository(
+    app,
+    await searchParams,
+  );
   const pageAuth = await readPageSessionRequest(app, "/review");
-  if (!pageAuth) {
+  const sessionMatchesRequestedRepository =
+    requestedRepository === undefined ||
+    (requestedRepository !== "invalid" &&
+      pageAuth?.session.repositoryId === requestedRepository.id);
+  if (
+    requestedRepository === "invalid" ||
+    !pageAuth ||
+    !sessionMatchesRequestedRepository
+  ) {
     return (
       <ReviewShell demoMode={app.config.DEMO_MODE}>
         <section className="notice-card review-empty">
           <p className="eyebrow">Protected review</p>
-          <h2>Maintainer authorization required.</h2>
+          <h2>
+            {pageAuth && !sessionMatchesRequestedRepository
+              ? "This session cannot review this repository."
+              : "Maintainer authorization required."}
+          </h2>
           {app.config.DEMO_MODE ? (
             <p>
               Evidence and review decisions are repository-bound. This local
               environment exposes a demo maintainer session for offline use.
+            </p>
+          ) : requestedRepository && requestedRepository !== "invalid" ? (
+            <p>
+              Evidence and review decisions stay bound to{" "}
+              {requestedRepository.owner}/{requestedRepository.name}. Authorize
+              with GitHub for this repository.
             </p>
           ) : (
             <p>
@@ -35,7 +63,13 @@ export default async function ReviewQueuePage() {
             <DemoMaintainerLogin />
           ) : (
             <GithubMaintainerLogin
-              repositories={await loadReviewLoginRepositories(app)}
+              repositories={
+                requestedRepository === "invalid"
+                  ? []
+                  : requestedRepository
+                    ? [requestedRepository]
+                    : await loadReviewLoginRepositories(app)
+              }
             />
           )}
         </section>
@@ -133,12 +167,30 @@ export default async function ReviewQueuePage() {
             <DemoMaintainerLogin />
           ) : (
             <GithubMaintainerLogin
-              repositories={await loadReviewLoginRepositories(app)}
+              repositories={
+                requestedRepository
+                  ? [requestedRepository]
+                  : await loadReviewLoginRepositories(app)
+              }
             />
           )}
         </section>
       </ReviewShell>
     );
+  }
+}
+
+async function loadRequestedReviewRepository(
+  app: Awaited<ReturnType<typeof getWebRuntime>>,
+  searchParams: { repositoryId?: string | string[] },
+): Promise<ActiveMaintainerRepositoryV1 | "invalid" | undefined> {
+  const raw = searchParams.repositoryId;
+  if (raw === undefined) return undefined;
+  if (Array.isArray(raw) || !z.uuid().safeParse(raw).success) return "invalid";
+  try {
+    return await loadActiveMaintainerRepository(app.database.pool, raw);
+  } catch {
+    return "invalid";
   }
 }
 

--- a/apps/web/app/review/page.tsx
+++ b/apps/web/app/review/page.tsx
@@ -227,7 +227,10 @@ function GithubMaintainerLogin({
     );
   }
   return (
-    <nav className="review-login review-repo-choice" aria-label="Choose repository">
+    <nav
+      className="review-login review-repo-choice"
+      aria-label="Choose repository"
+    >
       <p>Choose the repository to review.</p>
       <ul>
         {repositories.map((repository) => (

--- a/apps/web/app/review/page.tsx
+++ b/apps/web/app/review/page.tsx
@@ -12,15 +12,21 @@ export default async function ReviewQueuePage() {
   const pageAuth = await readPageSessionRequest(app, "/review");
   if (!pageAuth) {
     return (
-      <ReviewShell>
+      <ReviewShell demoMode={app.config.DEMO_MODE}>
         <section className="notice-card review-empty">
           <p className="eyebrow">Protected review</p>
           <h2>Maintainer authorization required.</h2>
-          <p>
-            Evidence and review decisions are repository-bound. The local MVP
-            exposes a demo maintainer session only while offline demo mode is
-            enabled.
-          </p>
+          {app.config.DEMO_MODE ? (
+            <p>
+              Evidence and review decisions are repository-bound. This local
+              environment exposes a demo maintainer session for offline use.
+            </p>
+          ) : (
+            <p>
+              Evidence and review decisions are repository-bound. Authorize with
+              GitHub to open the protected maintainer queue.
+            </p>
+          )}
           {app.config.DEMO_MODE ? (
             <DemoMaintainerLogin />
           ) : (
@@ -38,7 +44,7 @@ export default async function ReviewQueuePage() {
       pageAuth.session,
     );
     return (
-      <ReviewShell>
+      <ReviewShell demoMode={app.config.DEMO_MODE}>
         <div className="check-header">
           <div>
             <p className="eyebrow">
@@ -94,7 +100,7 @@ export default async function ReviewQueuePage() {
   } catch (error) {
     if (error instanceof WebRequestRateLimitExceededError) {
       return (
-        <ReviewShell>
+        <ReviewShell demoMode={app.config.DEMO_MODE}>
           <section className="notice-card review-empty">
             <p className="eyebrow">Protected review</p>
             <h2>Review refresh is temporarily limited.</h2>
@@ -109,7 +115,7 @@ export default async function ReviewQueuePage() {
     }
     if (!(error instanceof MaintainerAuthorizationError)) throw error;
     return (
-      <ReviewShell>
+      <ReviewShell demoMode={app.config.DEMO_MODE}>
         <section className="notice-card error-card review-empty">
           <p className="eyebrow">Access denied</p>
           <h2>This session cannot review this repository.</h2>
@@ -139,12 +145,20 @@ function GithubMaintainerLogin() {
   );
 }
 
-function ReviewShell({ children }: { children: React.ReactNode }) {
+function ReviewShell({
+  children,
+  demoMode,
+}: {
+  children: React.ReactNode;
+  demoMode: boolean;
+}) {
   return (
     <main className="shell flow-shell review-shell">
-      <a className="back-link" href="/demo">
-        ← Local demo
-      </a>
+      {demoMode ? (
+        <a className="back-link" href="/demo">
+          ← Local demo
+        </a>
+      ) : null}
       {children}
     </main>
   );

--- a/apps/web/app/revisions/[revisionId]/page.tsx
+++ b/apps/web/app/revisions/[revisionId]/page.tsx
@@ -5,6 +5,7 @@ import { getWebRuntime } from "../../../lib/runtime";
 export const dynamic = "force-dynamic";
 
 type PublicRevision = {
+  repository_id: string;
   owner: string;
   name: string;
   pull_request_number: number;
@@ -28,7 +29,7 @@ export default async function PublicRevisionPage({
   if (!revisionId.success) notFound();
   const app = await getWebRuntime();
   const result = await app.database.pool.query<PublicRevision>(
-    `SELECT repository.owner, repository.name,
+    `SELECT repository.id AS repository_id, repository.owner, repository.name,
             pull_request.number AS pull_request_number,
             revision.head_sha, revision.is_current,
             check_run.status, check_run.conclusion, check_run.public_summary,
@@ -82,7 +83,10 @@ export default async function PublicRevisionPage({
               Continue as contributor
             </a>
           ) : null}
-          <a className="button maintainer-button" href="/review">
+          <a
+            className="button maintainer-button"
+            href={`/review?repositoryId=${encodeURIComponent(revision.repository_id)}`}
+          >
             Protected maintainer view
           </a>
         </div>

--- a/apps/web/lib/github-oauth-production.test.ts
+++ b/apps/web/lib/github-oauth-production.test.ts
@@ -194,8 +194,12 @@ describe("production GitHub OAuth wiring", () => {
 
   it("lists only active owner/name pairs for the review login", async () => {
     const database = fakePool(async (sql, parameters) => {
-      expect(sql).toContain("SELECT repository.id, repository.owner, repository.name");
-      expect(sql).toContain("ORDER BY repository.owner, repository.name, repository.id");
+      expect(sql).toContain(
+        "SELECT repository.id, repository.owner, repository.name",
+      );
+      expect(sql).toContain(
+        "ORDER BY repository.owner, repository.name, repository.id",
+      );
       expect(parameters).toEqual([33]);
       return result([
         {

--- a/apps/web/lib/github-oauth-production.test.ts
+++ b/apps/web/lib/github-oauth-production.test.ts
@@ -5,6 +5,7 @@ import {
   PgGithubOAuthSessionPort,
   PgGithubOAuthStateRepository,
   createGithubOAuthProductionRuntime,
+  listActiveMaintainerRepositories,
   resolveProductionStartBinding,
 } from "./github-oauth-production";
 import { GithubOAuthWiringError } from "./github-oauth-runtime";
@@ -136,6 +137,92 @@ describe("production GitHub OAuth wiring", () => {
         "/review",
       ),
     ).rejects.toBeInstanceOf(GithubOAuthWiringError);
+  });
+
+  it("binds /review to an exact active local repository id", async () => {
+    const database = fakePool(async (sql, parameters) => {
+      expect(sql).toContain("WHERE repository.id = $1");
+      expect(sql).toContain("repository.status = 'active'");
+      expect(parameters).toEqual([REPOSITORY_ID]);
+      return result([
+        {
+          repository_id: REPOSITORY_ID,
+          github_repository_id: "987654321",
+        },
+      ]);
+    });
+    await expect(
+      resolveProductionStartBinding(
+        app(database.pool),
+        new Request(
+          `https://slopproof.example/api/auth/github/start?returnTo=${encodeURIComponent("/review")}&repositoryId=${REPOSITORY_ID}`,
+        ),
+        "/review",
+      ),
+    ).resolves.toEqual({
+      purpose: "maintainer_reauth",
+      repositoryId: REPOSITORY_ID,
+      githubRepositoryId: "987654321",
+    });
+    expect(database.query).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects unknown or malformed review repository ids", async () => {
+    const unknown = fakePool(async () => result());
+    await expect(
+      resolveProductionStartBinding(
+        app(unknown.pool),
+        new Request(
+          `https://slopproof.example/api/auth/github/start?repositoryId=${REPOSITORY_ID}`,
+        ),
+        "/review",
+      ),
+    ).rejects.toBeInstanceOf(GithubOAuthWiringError);
+
+    await expect(
+      resolveProductionStartBinding(
+        app(unknown.pool),
+        new Request(
+          "https://slopproof.example/api/auth/github/start?repositoryId=not-a-uuid",
+        ),
+        "/review",
+      ),
+    ).rejects.toBeInstanceOf(GithubOAuthWiringError);
+    expect(unknown.query).toHaveBeenCalledTimes(1);
+  });
+
+  it("lists only active owner/name pairs for the review login", async () => {
+    const database = fakePool(async (sql, parameters) => {
+      expect(sql).toContain("SELECT repository.id, repository.owner, repository.name");
+      expect(sql).toContain("ORDER BY repository.owner, repository.name, repository.id");
+      expect(parameters).toEqual([33]);
+      return result([
+        {
+          id: REPOSITORY_ID,
+          owner: "pascalkienast",
+          name: "pixelcampus",
+        },
+        {
+          id: "40000000-0000-4000-8000-000000000005",
+          owner: "pascalkienast",
+          name: "slopproof",
+        },
+      ]);
+    });
+    await expect(
+      listActiveMaintainerRepositories(database.pool),
+    ).resolves.toEqual([
+      {
+        id: REPOSITORY_ID,
+        owner: "pascalkienast",
+        name: "pixelcampus",
+      },
+      {
+        id: "40000000-0000-4000-8000-000000000005",
+        owner: "pascalkienast",
+        name: "slopproof",
+      },
+    ]);
   });
 
   it("prefers an active repository-bound session for /review", async () => {

--- a/apps/web/lib/github-oauth-production.test.ts
+++ b/apps/web/lib/github-oauth-production.test.ts
@@ -6,6 +6,7 @@ import {
   PgGithubOAuthStateRepository,
   createGithubOAuthProductionRuntime,
   listActiveMaintainerRepositories,
+  loadActiveMaintainerRepository,
   resolveProductionStartBinding,
 } from "./github-oauth-production";
 import { GithubOAuthWiringError } from "./github-oauth-runtime";
@@ -223,6 +224,31 @@ describe("production GitHub OAuth wiring", () => {
         name: "slopproof",
       },
     ]);
+  });
+
+  it("loads one active maintainer repository by local id", async () => {
+    const database = fakePool(async (sql, parameters) => {
+      expect(sql).toContain("WHERE repository.id = $1");
+      expect(sql).toContain("repository.status = 'active'");
+      expect(parameters).toEqual([REPOSITORY_ID]);
+      return result([
+        {
+          id: REPOSITORY_ID,
+          owner: "pascalkienast",
+          name: "slopproof",
+        },
+      ]);
+    });
+    await expect(
+      loadActiveMaintainerRepository(database.pool, REPOSITORY_ID),
+    ).resolves.toEqual({
+      id: REPOSITORY_ID,
+      owner: "pascalkienast",
+      name: "slopproof",
+    });
+    await expect(
+      loadActiveMaintainerRepository(database.pool, "not-a-uuid"),
+    ).rejects.toBeInstanceOf(GithubOAuthWiringError);
   });
 
   it("prefers an active repository-bound session for /review", async () => {

--- a/apps/web/lib/github-oauth-production.ts
+++ b/apps/web/lib/github-oauth-production.ts
@@ -73,6 +73,26 @@ const ActiveRepositoryRowSchema = z
   })
   .strict();
 
+const RepositoryOwnerNameSchema = z
+  .string()
+  .min(1)
+  .max(100)
+  .regex(/^[A-Za-z0-9_.-]+$/u);
+
+const ActiveMaintainerRepositorySchema = z
+  .object({
+    id: z.uuid(),
+    owner: RepositoryOwnerNameSchema,
+    name: RepositoryOwnerNameSchema,
+  })
+  .strict();
+
+export type ActiveMaintainerRepositoryV1 = z.infer<
+  typeof ActiveMaintainerRepositorySchema
+>;
+
+const MAX_ACTIVE_MAINTAINER_REPOSITORIES = 32;
+
 const StateRowSchema = z
   .object({
     state_hash: StateHashSchema,
@@ -615,6 +635,23 @@ export async function resolveProductionStartBinding(
   }
 
   if (redirectPath !== "/review") throw new GithubOAuthWiringError();
+  const selectedRepositoryId = requestedReviewRepositoryId(request);
+  if (selectedRepositoryId) {
+    return loadSingleActiveBinding(
+      app.database.pool,
+      `SELECT repository.id AS repository_id,
+              repository.github_repository_id
+         FROM repositories repository
+         JOIN installations installation
+           ON installation.id = repository.installation_id
+        WHERE repository.id = $1
+          AND repository.status = 'active'
+          AND installation.status = 'active'
+        LIMIT 1`,
+      [selectedRepositoryId],
+      "maintainer_reauth",
+    );
+  }
   const sessionToken = requestCookieValue(request, SESSION_COOKIE);
   if (sessionToken) {
     validateCredential(sessionToken);
@@ -693,6 +730,44 @@ function bindingFromRow(
   });
   if (!binding.success) throw new GithubOAuthWiringError();
   return binding.data;
+}
+
+function requestedReviewRepositoryId(request: Request): string | undefined {
+  const url = new URL(request.url);
+  const values = url.searchParams.getAll("repositoryId");
+  if (values.length === 0) return undefined;
+  if (values.length > 1) throw new GithubOAuthWiringError();
+  const repositoryId = z.uuid().safeParse(values[0]);
+  if (!repositoryId.success) throw new GithubOAuthWiringError();
+  return repositoryId.data;
+}
+
+export async function listActiveMaintainerRepositories(
+  pool: SqlPool,
+): Promise<readonly ActiveMaintainerRepositoryV1[]> {
+  const result = await pool.query<{
+    id: string;
+    owner: string;
+    name: string;
+  }>(
+    `SELECT repository.id, repository.owner, repository.name
+       FROM repositories repository
+       JOIN installations installation
+         ON installation.id = repository.installation_id
+      WHERE repository.status = 'active'
+        AND installation.status = 'active'
+      ORDER BY repository.owner, repository.name, repository.id
+      LIMIT $1`,
+    [MAX_ACTIVE_MAINTAINER_REPOSITORIES + 1],
+  );
+  if (result.rows.length > MAX_ACTIVE_MAINTAINER_REPOSITORIES) {
+    throw new GithubOAuthWiringError();
+  }
+  return result.rows.map((row) => {
+    const parsed = ActiveMaintainerRepositorySchema.safeParse(row);
+    if (!parsed.success) throw new GithubOAuthWiringError();
+    return parsed.data;
+  });
 }
 
 async function peekActiveStateRedirect(

--- a/apps/web/lib/github-oauth-production.ts
+++ b/apps/web/lib/github-oauth-production.ts
@@ -763,11 +763,41 @@ export async function listActiveMaintainerRepositories(
   if (result.rows.length > MAX_ACTIVE_MAINTAINER_REPOSITORIES) {
     throw new GithubOAuthWiringError();
   }
-  return result.rows.map((row) => {
-    const parsed = ActiveMaintainerRepositorySchema.safeParse(row);
-    if (!parsed.success) throw new GithubOAuthWiringError();
-    return parsed.data;
-  });
+  return result.rows.map(parseActiveMaintainerRepository);
+}
+
+export async function loadActiveMaintainerRepository(
+  pool: SqlPool,
+  repositoryId: string,
+): Promise<ActiveMaintainerRepositoryV1> {
+  const parsedId = z.uuid().safeParse(repositoryId);
+  if (!parsedId.success) throw new GithubOAuthWiringError();
+  const result = await pool.query<{
+    id: string;
+    owner: string;
+    name: string;
+  }>(
+    `SELECT repository.id, repository.owner, repository.name
+       FROM repositories repository
+       JOIN installations installation
+         ON installation.id = repository.installation_id
+      WHERE repository.id = $1
+        AND repository.status = 'active'
+        AND installation.status = 'active'
+      LIMIT 1`,
+    [parsedId.data],
+  );
+  const row = result.rows[0];
+  if (row === undefined) throw new GithubOAuthWiringError();
+  return parseActiveMaintainerRepository(row);
+}
+
+function parseActiveMaintainerRepository(
+  row: unknown,
+): ActiveMaintainerRepositoryV1 {
+  const parsed = ActiveMaintainerRepositorySchema.safeParse(row);
+  if (!parsed.success) throw new GithubOAuthWiringError();
+  return parsed.data;
 }
 
 async function peekActiveStateRedirect(

--- a/apps/web/lib/github-oauth-routes.test.ts
+++ b/apps/web/lib/github-oauth-routes.test.ts
@@ -140,6 +140,30 @@ describe("GitHub OAuth route handlers", () => {
     expect(await rateLimited.json()).toEqual({ error: "rate_limited" });
   });
 
+  it("allows a local review repositoryId and rejects extra start parameters", async () => {
+    const allowed = harness();
+    const response = await handleGithubOAuthStart(
+      new Request(
+        `https://slopproof.example/api/auth/github/start?returnTo=${encodeURIComponent("/review")}&repositoryId=${REPOSITORY_ID}`,
+      ),
+      allowed.resolve,
+    );
+    expect(response.status).toBe(302);
+    expect(allowed.resolveStartBinding).toHaveBeenCalledWith({
+      request: expect.any(Request),
+      requestedRedirectPath: "/review",
+    });
+
+    const rejected = await handleGithubOAuthStart(
+      new Request(
+        `https://slopproof.example/api/auth/github/start?returnTo=${encodeURIComponent("/review")}&repositoryId=${REPOSITORY_ID}&repositoryId=${REPOSITORY_ID}`,
+      ),
+      harness().resolve,
+    );
+    expect(rejected.status).toBe(400);
+    expect(await rejected.json()).toEqual({ error: "oauth_rejected" });
+  });
+
   it("rotates session and sets only sealed Fresh-Auth material on callback", async () => {
     const test = harness();
     const response = await handleGithubOAuthCallback(

--- a/apps/web/lib/github-oauth-routes.ts
+++ b/apps/web/lib/github-oauth-routes.ts
@@ -44,7 +44,7 @@ export async function handleGithubOAuthStart(
 ): Promise<NextResponse> {
   try {
     const url = exactRouteUrl(request, "GET", START_PATH);
-    rejectUnknownQuery(url, new Set(["returnTo"]));
+    rejectUnknownQuery(url, new Set(["returnTo", "repositoryId"]));
     const requestedRedirectPath = singleQueryValue(url, "returnTo");
     const runtime = await resolvedRuntime(resolve, request);
     const binding = await runtime.resolveStartBinding({

--- a/apps/worker/src/audio-transcription.test.ts
+++ b/apps/worker/src/audio-transcription.test.ts
@@ -384,7 +384,7 @@ describe("worker-only recording audio transcription", () => {
     }
   });
 
-  it("rejects contradictory per-question detected languages and propagates technical provider retries", async () => {
+  it("marks mixed per-question detected languages as undetermined and propagates technical provider retries", async () => {
     let call = 0;
     const contradictory = await dependencies({
       mutateProviderResult(value) {
@@ -398,7 +398,7 @@ describe("worker-only recording audio transcription", () => {
         ciphertextAccess(),
         providerContext(),
       ),
-    ).rejects.toMatchObject({ code: "INVALID_OUTPUT", disposition: "review" });
+    ).resolves.toMatchObject({ language: "und" });
 
     const retry = new ProviderError(
       "PROVIDER_UNAVAILABLE",

--- a/apps/worker/src/audio-transcription.test.ts
+++ b/apps/worker/src/audio-transcription.test.ts
@@ -532,6 +532,49 @@ describe("bounded FFmpeg audio pipeline", () => {
     expect(first[44]).toBe(1);
     expect(second[44]).toBe(2);
   });
+
+  it("clamps a 12ms last-question tail that overruns decoded PCM", () => {
+    const pcm = patternedPcm(1_988);
+    const wav = questionWavFromPcm(
+      pcm,
+      interval(QUESTION_TWO, 1, 1_000, 2_000),
+    );
+    expect(new DataView(wav.buffer).getUint32(40, true)).toBe(988 * 32);
+    expect(wav.subarray(44)).toEqual(pcm.subarray(1_000 * 32));
+  });
+
+  it("still rejects a last-question tail that overruns decoded PCM by more than 250ms", () => {
+    expect(() =>
+      questionWavFromPcm(
+        patternedPcm(1_700),
+        interval(QUESTION_TWO, 1, 1_000, 2_000),
+      ),
+    ).toThrow(
+      expect.objectContaining({
+        code: "INVALID_OUTPUT",
+        disposition: "review",
+      }),
+    );
+  });
+
+  it("transcribes when the last stored interval ends 12ms after decoded audio", async () => {
+    const fixture = await dependencies({ pcm: patternedPcm(1_988) });
+    const transcript = await fixture.adapter.transcribe(
+      recordingSource(),
+      ciphertextAccess(),
+      providerContext(),
+    );
+    expect(fixture.provider.transcribeQuestion).toHaveBeenCalledTimes(2);
+    expect(
+      fixture.requests.map((request) => [request.startMs, request.endMs]),
+    ).toEqual([
+      [0, 1_000],
+      [1_000, 2_000],
+    ]);
+    expect(fixture.requests[1]?.audio.byteLength).toBe(44 + 988 * 32);
+    expect(transcript.segments).toHaveLength(2);
+    expect(transcript.durationMs).toBe(2_000);
+  });
 });
 
 type DependencyOptions = {

--- a/apps/worker/src/audio-transcription.ts
+++ b/apps/worker/src/audio-transcription.ts
@@ -40,6 +40,7 @@ const WAV_HEADER_BYTES = 44;
 const MAX_PCM_BYTES = 16 * 1_024 * 1_024;
 const MAX_QUESTION_AUDIO_BYTES = 16 * 1_024 * 1_024;
 const MAX_DECODE_DURATION_DRIFT_MS = 1_500;
+const MAX_QUESTION_CLIP_END_CLAMP_MS = 250;
 const DEFAULT_FFMPEG_TIMEOUT_MS = 120_000;
 
 export const RecordingAudioTranscriptionSourceV1Schema = z
@@ -686,11 +687,16 @@ export function questionWavFromPcm(
   const startByte = Math.floor(
     interval.data.startMs * PCM_BYTES_PER_MILLISECOND,
   );
-  const endByte = Math.floor(interval.data.endMs * PCM_BYTES_PER_MILLISECOND);
+  const requestedEndByte = Math.floor(
+    interval.data.endMs * PCM_BYTES_PER_MILLISECOND,
+  );
+  const alignedPcmBytes =
+    pcm.byteLength - (pcm.byteLength % PCM_BYTES_PER_SAMPLE);
+  const endByte = clampQuestionClipEndByte(requestedEndByte, alignedPcmBytes);
   const dataBytes = endByte - startByte;
   if (
     startByte < 0 ||
-    endByte > pcm.byteLength ||
+    endByte > alignedPcmBytes ||
     dataBytes <= 0 ||
     dataBytes + WAV_HEADER_BYTES > MAX_QUESTION_AUDIO_BYTES ||
     dataBytes % PCM_BYTES_PER_SAMPLE !== 0
@@ -720,6 +726,17 @@ export function questionWavFromPcm(
   view.setUint32(40, dataBytes, true);
   wav.set(pcm.subarray(startByte, endByte), WAV_HEADER_BYTES);
   return wav;
+}
+
+function clampQuestionClipEndByte(
+  requestedEndByte: number,
+  pcmByteLength: number,
+): number {
+  if (requestedEndByte <= pcmByteLength) return requestedEndByte;
+  const overflowBytes = requestedEndByte - pcmByteLength;
+  const overflowMs = overflowBytes / PCM_BYTES_PER_MILLISECOND;
+  if (overflowMs > MAX_QUESTION_CLIP_END_CLAMP_MS) return requestedEndByte;
+  return pcmByteLength;
 }
 
 function writeAscii(bytes: Uint8Array, offset: number, value: string): void {

--- a/apps/worker/src/audio-transcription.ts
+++ b/apps/worker/src/audio-transcription.ts
@@ -553,17 +553,16 @@ function assembleTranscript(
     );
   }
   const languages = new Set(
-    results.map((result) => baseLanguage(result.language)),
+    results
+      .map((result) => baseLanguage(result.language))
+      .filter((language) => language !== "und"),
   );
-  if (languages.size !== 1) {
-    throw reviewOutputError(
-      "Question transcripts contain contradictory detected languages",
-    );
-  }
   const language =
     source.languagePolicy.mode === "fixed"
       ? source.languagePolicy.language
-      : results[0]?.language;
+      : languages.size === 1
+        ? [...languages][0]
+        : "und";
   if (language === undefined) {
     throw reviewOutputError("Transcription did not produce a language");
   }

--- a/apps/worker/src/provider-pipeline-contracts.ts
+++ b/apps/worker/src/provider-pipeline-contracts.ts
@@ -14,7 +14,11 @@ import {
   ProviderRecommendationSchema,
   RepositoryPolicyV1Schema,
 } from "@slopproof/policy";
-import { FrameSelectionMetadataV1Schema } from "@slopproof/providers";
+import {
+  FrameSelectionMetadataV1Schema,
+  type ProviderErrorCode,
+  type ProviderFailureTelemetry,
+} from "@slopproof/providers";
 import { z } from "zod";
 import { RecordingAudioTranscriptionSourceV1Schema } from "./audio-transcription";
 
@@ -249,6 +253,8 @@ export interface ProviderPipelineRepository {
     idempotencyKey: string;
     evaluationId?: string;
     providerRecommendation?: "pass" | "review_required" | "retry";
+    providerErrorCode?: ProviderErrorCode;
+    providerFailureTelemetry?: ProviderFailureTelemetry;
     reason: "valid_policy" | "provider_manual_review";
   }): Promise<"updated" | "replayed" | "stale">;
   transitionToTechnicalRetry(input: {

--- a/apps/worker/src/provider-pipeline-repository.ts
+++ b/apps/worker/src/provider-pipeline-repository.ts
@@ -6,6 +6,10 @@ import {
 } from "@slopproof/db";
 import { FinalizeRecordingSchema } from "@slopproof/media";
 import type { RepositoryPolicyV1 } from "@slopproof/policy";
+import type {
+  ProviderErrorCode,
+  ProviderFailureTelemetry,
+} from "@slopproof/providers";
 import {
   EncryptedEvaluationBundleV1Schema,
   EncryptedTranscriptBundleV1Schema,
@@ -1070,6 +1074,8 @@ export class PostgresProviderPipelineRepository implements ProviderPipelineRepos
     idempotencyKey: string;
     evaluationId?: string;
     providerRecommendation?: "pass" | "review_required" | "retry";
+    providerErrorCode?: ProviderErrorCode;
+    providerFailureTelemetry?: ProviderFailureTelemetry;
     reason: "valid_policy" | "provider_manual_review";
   }): Promise<"updated" | "replayed" | "stale"> {
     const client = await this.database.pool.connect();
@@ -1161,12 +1167,23 @@ export class PostgresProviderPipelineRepository implements ProviderPipelineRepos
          VALUES ('provider-pipeline', 'attempt.review_required', 'attempt', $1,
                  jsonb_build_object('reason', $2::text,
                                     'evaluationId', $3::text,
-                                    'providerRecommendation', $4::text))`,
+                                    'providerRecommendation', $4::text) ||
+                 CASE WHEN $5::text IS NULL THEN '{}'::jsonb ELSE
+                   jsonb_build_object(
+                     'providerErrorCode', $5::text,
+                     'providerFailureKind', $6::text,
+                     'providerHttpStatusClass', $7::text,
+                     'providerTransportAttemptCount', $8::integer)
+                 END)`,
         [
           input.attemptId,
           input.reason,
           input.evaluationId ?? null,
           input.providerRecommendation ?? null,
+          input.providerErrorCode ?? null,
+          input.providerFailureTelemetry?.lastFailureKind ?? null,
+          input.providerFailureTelemetry?.httpStatusClass ?? null,
+          input.providerFailureTelemetry?.transportAttemptCount ?? null,
         ],
       );
       await this.checkIntents.write(client, {

--- a/apps/worker/src/provider-pipeline.test.ts
+++ b/apps/worker/src/provider-pipeline.test.ts
@@ -1111,9 +1111,17 @@ describe("provider worker pipeline", () => {
           "INVALID_OUTPUT",
           "review",
           "synthetic invalid provider output",
+          {
+            telemetry: {
+              lastFailureKind: "invalid_output",
+              httpStatusClass: null,
+              transportAttemptCount: 1,
+            },
+          },
         );
       },
     };
+    const transition = vi.spyOn(base.repository, "transitionToReviewRequired");
     const handlers = createProviderPipelineHandlers({
       repository: base.repository,
       dispatcher: base.dispatcher,
@@ -1137,6 +1145,16 @@ describe("provider worker pipeline", () => {
     expect(outcome.outcome).toBe("manual_review");
     expect(base.repository.status).toBe("review_required");
     expect(base.repository.transitions).toEqual(["provider_manual_review"]);
+    expect(transition).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerErrorCode: "INVALID_OUTPUT",
+        providerFailureTelemetry: {
+          lastFailureKind: "invalid_output",
+          httpStatusClass: null,
+          transportAttemptCount: 1,
+        },
+      }),
+    );
   });
 
   it("routes terminal provider failures to technical retry", async () => {

--- a/apps/worker/src/provider-pipeline.ts
+++ b/apps/worker/src/provider-pipeline.ts
@@ -478,6 +478,10 @@ async function routeProviderFailure(
       expectedHeadSha: job.expectedHeadSha,
       idempotencyKey: nextIdempotencyKey(job.idempotencyKey, "manual-review"),
       reason: "provider_manual_review",
+      providerErrorCode: providerError.code,
+      ...(providerError.telemetry === undefined
+        ? {}
+        : { providerFailureTelemetry: providerError.telemetry }),
     });
     return result({
       stage,

--- a/packages/providers/src/openrouter-transcription.test.ts
+++ b/packages/providers/src/openrouter-transcription.test.ts
@@ -67,7 +67,7 @@ describe("OpenRouter transcription provider", () => {
     expect(form).toBeInstanceOf(FormData);
     if (!(form instanceof FormData)) throw new Error("missing multipart body");
     expect(form.get("model")).toBe("openai/whisper-large-v3-turbo");
-    expect(form.get("response_format")).toBe("verbose_json");
+    expect(form.get("response_format")).toBe("json");
     expect(form.get("store")).toBe("false");
     expect(form.get("language")).toBeNull();
     const file = form.get("file");
@@ -195,7 +195,7 @@ describe("OpenRouter transcription provider", () => {
     expect(sleep).not.toHaveBeenCalled();
   });
 
-  it("rejects malformed, oversized, empty and contradictory success envelopes without retry", async () => {
+  it("rejects malformed, oversized, empty and fixed-language contradictory success envelopes without retry", async () => {
     const fixtures = [
       new Response("not-json", { status: 200 }),
       new Response("{}", {
@@ -204,8 +204,6 @@ describe("OpenRouter transcription provider", () => {
       }),
       Response.json({ text: "   ", language: "en" }),
       Response.json({ text: "Bound answer", language: "german" }),
-      Response.json({ text: "Bound answer", language: "en", duration: 9 }),
-      Response.json({ text: "Bound answer", language: "en", duration: 0.1 }),
       new Response("{}", {
         status: 200,
         headers: { "content-length": "not-a-number" },
@@ -227,6 +225,26 @@ describe("OpenRouter transcription provider", () => {
         disposition: "review",
       });
       expect(fetchImpl).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("accepts the documented text-only response and ignores advisory duration drift", async () => {
+    const responses = [
+      Response.json({ text: "Bound answer", usage: { seconds: 1 } }),
+      Response.json({
+        text: "Bound answer",
+        language: null,
+        duration: 99,
+      }),
+    ];
+    for (const response of responses) {
+      const provider = new OpenRouterTranscriptionProvider(
+        configuration(),
+        dependencies(vi.fn<typeof fetch>().mockResolvedValue(response)),
+      );
+      await expect(
+        provider.transcribeQuestion(request(), context()),
+      ).resolves.toMatchObject({ language: "und" });
     }
   });
 

--- a/packages/providers/src/openrouter-transcription.ts
+++ b/packages/providers/src/openrouter-transcription.ts
@@ -7,6 +7,10 @@ import {
   type ProviderContextV1,
 } from "./contracts";
 import { ProviderError } from "./errors";
+import type {
+  ProviderFailureTelemetry,
+  ProviderHttpStatusClass,
+} from "./errors";
 
 const MAX_HTTP_ATTEMPTS = 3;
 const DEFAULT_ATTEMPT_TIMEOUT_MS = 30_000;
@@ -159,14 +163,16 @@ type ResolvedRequestPolicy = {
 
 type RetryableFailure = {
   kind: "network" | "timeout" | "rate_limited" | "unavailable";
+  httpStatusClass?: ProviderHttpStatusClass;
   retryAfterMs?: number;
 };
 
-const OpenRouterVerboseTranscriptionSchema = z
+const OpenRouterTranscriptionResponseSchema = z
   .object({
     text: z.string(),
-    language: z.string().min(1).max(100),
-    duration: z.number().finite().nonnegative().optional(),
+    language: z.unknown().optional(),
+    duration: z.unknown().optional(),
+    usage: z.unknown().optional(),
   })
   .passthrough();
 
@@ -221,7 +227,7 @@ export class OpenRouterTranscriptionProvider {
       );
     }
 
-    const rawResponse = await requestTranscriptionWithRetry({
+    const response = await requestTranscriptionWithRetry({
       endpoint: this.endpoint,
       apiKey: this.apiKey,
       model: this.descriptor.model,
@@ -231,40 +237,34 @@ export class OpenRouterTranscriptionProvider {
       fetchImpl: this.fetchImpl,
       policy: this.policy,
     });
-    const parsedResponse =
-      OpenRouterVerboseTranscriptionSchema.safeParse(rawResponse);
-    if (!parsedResponse.success) throw invalidOutputError();
+    const parsedResponse = OpenRouterTranscriptionResponseSchema.safeParse(
+      response.payload,
+    );
+    if (!parsedResponse.success) {
+      throw invalidOutputError(response.transportAttemptCount);
+    }
     const text = parsedResponse.data.text.trim();
     if (
       text.length === 0 ||
       Buffer.byteLength(text, "utf8") > MAX_TRANSCRIPT_BYTES ||
       text.includes("\0")
     ) {
-      throw invalidOutputError();
+      throw invalidOutputError(response.transportAttemptCount);
     }
-    const language = normalizeDetectedLanguage(parsedResponse.data.language);
+    const language =
+      typeof parsedResponse.data.language === "string"
+        ? normalizeDetectedLanguage(parsedResponse.data.language)
+        : undefined;
     if (
-      language === undefined ||
-      (input.languagePolicy.mode === "fixed" &&
-        baseLanguage(language) !== baseLanguage(input.languagePolicy.language))
+      input.languagePolicy.mode === "fixed" &&
+      language !== undefined &&
+      baseLanguage(language) !== baseLanguage(input.languagePolicy.language)
     ) {
       throw safeProviderError(
         "INVALID_OUTPUT",
         "review",
         "Transcription language contradicts the accepted language policy",
-      );
-    }
-    const expectedDurationMs = input.endMs - input.startMs;
-    const durationToleranceMs = Math.max(500, expectedDurationMs * 0.1);
-    if (
-      parsedResponse.data.duration !== undefined &&
-      Math.abs(parsedResponse.data.duration * 1_000 - expectedDurationMs) >
-        durationToleranceMs
-    ) {
-      throw safeProviderError(
-        "INVALID_OUTPUT",
-        "review",
-        "Transcription duration contradicts the bounded question interval",
+        invalidOutputTelemetry(response.transportAttemptCount),
       );
     }
 
@@ -280,7 +280,7 @@ export class OpenRouterTranscriptionProvider {
       language:
         input.languagePolicy.mode === "fixed"
           ? input.languagePolicy.language
-          : language,
+          : (language ?? "und"),
       text: {
         trust: "untrusted",
         source: "transcript",
@@ -303,7 +303,7 @@ async function requestTranscriptionWithRetry(input: {
   deadlineAtMs: number;
   fetchImpl: typeof fetch;
   policy: ResolvedRequestPolicy;
-}): Promise<unknown> {
+}): Promise<{ payload: unknown; transportAttemptCount: number }> {
   let lastFailure: RetryableFailure | undefined;
   for (let attempt = 1; attempt <= input.policy.maxAttempts; attempt += 1) {
     const remaining = input.deadlineAtMs - input.policy.now();
@@ -342,7 +342,7 @@ async function requestTranscriptionWithRetry(input: {
           throw new SafeProtocolError("malformed_response");
         }
       })();
-      return await Promise.race([
+      const payload = await Promise.race([
         operation,
         new Promise<never>((_resolve, reject) => {
           timeout = setTimeout(
@@ -354,12 +354,13 @@ async function requestTranscriptionWithRetry(input: {
           );
         }),
       ]);
+      return { payload, transportAttemptCount: attempt };
     } catch (error) {
       if (error instanceof SafeProtocolError) {
         if (error.kind === "response_stream") {
           lastFailure = { kind: "network" };
         } else {
-          throw invalidOutputError();
+          throw invalidOutputError(attempt);
         }
       } else if (isResponseStatusMarker(error)) {
         try {
@@ -370,6 +371,7 @@ async function requestTranscriptionWithRetry(input: {
         if (error.status === 429) {
           lastFailure = {
             kind: "rate_limited",
+            httpStatusClass: "4xx",
             ...(response === undefined
               ? {}
               : {
@@ -380,12 +382,17 @@ async function requestTranscriptionWithRetry(input: {
                 }),
           };
         } else if (error.status >= 500 && error.status <= 599) {
-          lastFailure = { kind: "unavailable" };
+          lastFailure = { kind: "unavailable", httpStatusClass: "5xx" };
         } else {
           throw safeProviderError(
             "PROVIDER_UNAVAILABLE",
             "terminal",
             "OpenRouter rejected the bounded transcription request",
+            {
+              lastFailureKind: "request_rejected",
+              httpStatusClass: "4xx",
+              transportAttemptCount: attempt,
+            },
           );
         }
       } else {
@@ -399,18 +406,22 @@ async function requestTranscriptionWithRetry(input: {
     }
 
     if (attempt === input.policy.maxAttempts) {
-      throw retryableProviderError(lastFailure);
+      throw retryableProviderError(lastFailure, attempt);
     }
     const delay = Math.max(
       jitteredBackoffMilliseconds(attempt, input.policy.random),
       lastFailure?.retryAfterMs ?? 0,
     );
     if (input.deadlineAtMs - input.policy.now() <= delay) {
-      throw deadlineError();
+      throw deadlineError({
+        lastFailureKind: "deadline_exceeded",
+        httpStatusClass: lastFailure?.httpStatusClass ?? null,
+        transportAttemptCount: attempt,
+      });
     }
     await input.policy.sleep(delay);
   }
-  throw retryableProviderError(lastFailure);
+  throw retryableProviderError(lastFailure, input.policy.maxAttempts);
 }
 
 function buildMultipartRequest(
@@ -420,7 +431,7 @@ function buildMultipartRequest(
 ): FormData {
   const form = new FormData();
   form.set("model", model);
-  form.set("response_format", "verbose_json");
+  form.set("response_format", "json");
   form.set("store", "false");
   if (languagePolicy.mode === "fixed") {
     form.set("language", languagePolicy.language);
@@ -717,8 +728,14 @@ function safeProviderError(
   code: ConstructorParameters<typeof ProviderError>[0],
   disposition: ConstructorParameters<typeof ProviderError>[1],
   message: string,
+  telemetry?: ProviderFailureTelemetry,
 ): ProviderError {
-  return new ProviderError(code, disposition, message);
+  return new ProviderError(
+    code,
+    disposition,
+    message,
+    telemetry === undefined ? undefined : { telemetry },
+  );
 }
 
 function invalidInputAudioError(): ProviderError {
@@ -729,28 +746,55 @@ function invalidInputAudioError(): ProviderError {
   );
 }
 
-function invalidOutputError(): ProviderError {
+function invalidOutputTelemetry(
+  transportAttemptCount: number,
+): ProviderFailureTelemetry {
+  return {
+    lastFailureKind: "invalid_output",
+    httpStatusClass: null,
+    transportAttemptCount,
+  };
+}
+
+function invalidOutputError(transportAttemptCount = 0): ProviderError {
   return safeProviderError(
     "INVALID_OUTPUT",
     "review",
     "Transcription provider returned an invalid bounded response",
+    invalidOutputTelemetry(transportAttemptCount),
   );
 }
 
-function deadlineError(): ProviderError {
+function deadlineError(telemetry?: ProviderFailureTelemetry): ProviderError {
   return safeProviderError(
     "DEADLINE_EXCEEDED",
     "retryable",
     "Transcription provider deadline was exceeded",
+    telemetry ?? {
+      lastFailureKind: "deadline_exceeded",
+      httpStatusClass: null,
+      transportAttemptCount: 0,
+    },
   );
 }
 
-function retryableProviderError(failure?: RetryableFailure): ProviderError {
+function retryableProviderError(
+  failure: RetryableFailure | undefined,
+  transportAttemptCount: number,
+): ProviderError {
   return safeProviderError(
     "PROVIDER_UNAVAILABLE",
     "retryable",
     failure?.kind === "rate_limited"
       ? "Transcription provider remained rate limited"
       : "Transcription provider remained unavailable",
+    {
+      lastFailureKind:
+        failure?.kind === "unavailable"
+          ? "upstream_unavailable"
+          : (failure?.kind ?? "network"),
+      httpStatusClass: failure?.httpStatusClass ?? null,
+      transportAttemptCount,
+    },
   );
 }

--- a/scripts/lib/production-operations.test.mjs
+++ b/scripts/lib/production-operations.test.mjs
@@ -49,10 +49,29 @@ test("landing interactions obey the strict script policy and default to Proof", 
   assert.match(landing, /class="check-choice proof active"/u);
   assert.match(landing, /class="check-choice optional"/u);
   assert.match(landing, /Optional: practice the patch/u);
+  assert.match(
+    landing,
+    /href="https:\/\/github\.com\/pascalkienast\/slopproof"[^>]*>Open-source MVP · Live on GitHub · 2026<\/a>/u,
+  );
+  assert.doesNotMatch(landing, /Open-source product concept/u);
   assert.doesNotMatch(landing, /fonts\.(?:googleapis|gstatic)\.com/u);
   assert.match(landing, /rel="icon" href="data:image\/svg\+xml/u);
   assert.match(behavior, /panel\.hidden = !selected/u);
   assert.match(behavior, /\[data-open-mode\]/u);
+});
+
+test("production review chrome does not expose the local demo", () => {
+  const reviewPage = read("apps/web/app/review/page.tsx");
+
+  assert.match(
+    reviewPage,
+    /demoMode \? \([\s\S]*?← Local demo[\s\S]*?\) : null/u,
+  );
+  assert.match(
+    reviewPage,
+    /Authorize with\s+GitHub to open the protected maintainer queue/u,
+  );
+  assert.doesNotMatch(reviewPage, /The local MVP exposes a demo maintainer/u);
 });
 
 test("Caddy preserves mobile capture and strips private access-log fields", () => {

--- a/scripts/lib/production-operations.test.mjs
+++ b/scripts/lib/production-operations.test.mjs
@@ -62,6 +62,7 @@ test("landing interactions obey the strict script policy and default to Proof", 
 
 test("production review chrome does not expose the local demo", () => {
   const reviewPage = read("apps/web/app/review/page.tsx");
+  const revisionPage = read("apps/web/app/revisions/[revisionId]/page.tsx");
 
   assert.match(
     reviewPage,
@@ -76,6 +77,11 @@ test("production review chrome does not expose the local demo", () => {
     reviewPage,
     /returnTo=\$\{encodeURIComponent\("\/review"\)\}&repositoryId=\$\{encodeURIComponent\(repositoryId\)\}/u,
   );
+  assert.match(
+    revisionPage,
+    /\/review\?repositoryId=\$\{encodeURIComponent\(revision\.repository_id\)\}/u,
+  );
+  assert.doesNotMatch(revisionPage, /href="\/review"/u);
   assert.doesNotMatch(reviewPage, /githubRepositoryId/u);
   assert.doesNotMatch(reviewPage, /The local MVP exposes a demo maintainer/u);
 });

--- a/scripts/lib/production-operations.test.mjs
+++ b/scripts/lib/production-operations.test.mjs
@@ -71,6 +71,12 @@ test("production review chrome does not expose the local demo", () => {
     reviewPage,
     /Authorize with\s+GitHub to open the protected maintainer queue/u,
   );
+  assert.match(reviewPage, /Choose the repository to review/u);
+  assert.match(
+    reviewPage,
+    /returnTo=\$\{encodeURIComponent\("\/review"\)\}&repositoryId=\$\{encodeURIComponent\(repositoryId\)\}/u,
+  );
+  assert.doesNotMatch(reviewPage, /githubRepositoryId/u);
   assert.doesNotMatch(reviewPage, /The local MVP exposes a demo maintainer/u);
 });
 

--- a/slopproof-brand-ui-concept-v3.html
+++ b/slopproof-brand-ui-concept-v3.html
@@ -279,6 +279,8 @@
     .closing-loop { width: 860px; max-width: 100%; margin: -35px auto -20px; display: block; }
     footer { padding: 30px 0; border-top: var(--line); background: var(--sheet); }
     .footer-row { display: flex; justify-content: space-between; gap: 24px; font: 500 11px/1.4 var(--mono); }
+    .footer-row a { color: inherit; text-underline-offset: 3px; }
+    .footer-row a:hover { color: var(--orange); }
 
     dialog { width: min(430px, calc(100% - 28px)); padding: 0; border: 0; border-radius: 34px; background: transparent; color: var(--ink); }
     dialog::backdrop { background: rgba(23,23,17,.82); backdrop-filter: blur(4px); }
@@ -533,7 +535,7 @@
     </section>
   </main>
 
-  <footer><div class="shell footer-row"><span>SLOP/PROOF · PROVE YOU KNOW WHAT YOU SHIP.</span><span>Open-source product concept · 2026</span></div></footer>
+  <footer><div class="shell footer-row"><span>SLOP/PROOF · PROVE YOU KNOW WHAT YOU SHIP.</span><a href="https://github.com/pascalkienast/slopproof" rel="noreferrer">Open-source MVP · Live on GitHub · 2026</a></div></footer>
 
   <dialog id="proof-dialog" aria-labelledby="dialog-title">
     <div class="dialog-card">

--- a/tests/e2e/mvp-ui.spec.ts
+++ b/tests/e2e/mvp-ui.spec.ts
@@ -38,7 +38,10 @@ test("offers one contributor entry and one protected maintainer entry", async ({
   ).toHaveAttribute("href", `/revisions/${revisionId}/contribute`);
   await expect(
     page.getByRole("link", { name: "Protected maintainer view" }),
-  ).toHaveAttribute("href", "/review");
+  ).toHaveAttribute(
+    "href",
+    "/review?repositoryId=50000000-0000-4000-8000-000000000002",
+  );
   await expect(page.getByText("Practice first (optional)")).toHaveCount(0);
   await expect(
     page.getByText(/contributors choose between optional practice/iu),


### PR DESCRIPTION
## What

- accept OpenRouter's documented text-only STT response and stop treating advisory duration/language metadata as proof bindings
- preserve local WAV/hash/question-interval validation, mark missing or mixed detected language as `und`, and retain content-free provider failure telemetry
- replace the landing-page concept label with a live public-repository link
- remove local-demo chrome and copy from production `/review`

Fixes #8.

## Verification

- `pnpm verify`
- `pnpm format:check`
- 704 unit tests
- 106 PostgreSQL integration tests
- targeted transcription, pipeline, landing and production review regression tests

## Rollout

The production rollout still follows the release-bundle, image/SBOM/Trivy, encrypted backup/restore rehearsal and managed-finalize runbook.
