### PR TITLE
feat: OpenRouter MiMo primary with Hetzner transport-only fallback

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -16,18 +16,27 @@ GITHUB_WEBHOOK_SECRET=replace-with-at-least-32-random-characters
 GITHUB_CLIENT_ID=replace-with-github-client-id
 GITHUB_CLIENT_SECRET=replace-with-github-client-secret
 
-GENERATION_PROVIDER=hetzner
-GENERATION_BASE_URL=https://inference.example.com/v1
+GENERATION_PROVIDER=openrouter
+GENERATION_BASE_URL=https://openrouter.ai/api/v1
 GENERATION_API_KEY=replace-with-generation-provider-key
-LEARNING_MODEL=replace-with-learning-model
-PRACTICE_MODEL=replace-with-practice-model
-PROOF_QUESTION_MODEL=replace-with-proof-question-model
+LEARNING_MODEL=xiaomi/mimo-v2.5
+PRACTICE_MODEL=xiaomi/mimo-v2.5
+PROOF_QUESTION_MODEL=xiaomi/mimo-v2.5
+GENERATION_FALLBACK_BASE_URL=https://inference.example.com/v1
+GENERATION_FALLBACK_API_KEY=replace-with-hetzner-generation-key
+LEARNING_FALLBACK_MODEL=replace-with-hetzner-learning-model
+PRACTICE_FALLBACK_MODEL=replace-with-hetzner-practice-model
+PROOF_QUESTION_FALLBACK_MODEL=replace-with-hetzner-proof-model
 
-MULTIMODAL_JUDGE_PROVIDER=hetzner
-JUDGE_BASE_URL=https://inference.example.com/v1
+MULTIMODAL_JUDGE_PROVIDER=openrouter
+JUDGE_BASE_URL=https://openrouter.ai/api/v1
 JUDGE_API_KEY=replace-with-judge-provider-key
-JUDGE_MODEL=replace-with-judge-model
-JUDGE_FALLBACK_MODEL=replace-with-fallback-model
+JUDGE_MODEL=xiaomi/mimo-v2.5
+JUDGE_FALLBACK_MODEL=xiaomi/mimo-v2.5
+JUDGE_TRANSPORT_FALLBACK_BASE_URL=https://inference.example.com/v1
+JUDGE_TRANSPORT_FALLBACK_API_KEY=replace-with-hetzner-judge-key
+JUDGE_TRANSPORT_FALLBACK_MODEL=replace-with-hetzner-judge-model
+JUDGE_TRANSPORT_FALLBACK_VISION_MODEL=replace-with-hetzner-vision-model
 
 TRANSCRIPTION_PROVIDER=openrouter
 TRANSCRIPTION_BASE_URL=https://transcription.example.com/v1

--- a/apps/worker/src/multimodal-judge-service.ts
+++ b/apps/worker/src/multimodal-judge-service.ts
@@ -124,7 +124,12 @@ export async function runMultimodalJudgeEvaluation(
             dependencies.provider.evaluate(providerInput, context.data),
           ),
           providerInput,
-          dependencies.provider.descriptor,
+          [
+            dependencies.provider.descriptor,
+            ...(dependencies.provider.transportFallbackDescriptor === undefined
+              ? []
+              : [dependencies.provider.transportFallbackDescriptor]),
+          ],
         );
         assertProviderCompletionBounds(
           providerResult.metadata.completedAt,

--- a/apps/worker/src/multimodal-provider-factory.test.ts
+++ b/apps/worker/src/multimodal-provider-factory.test.ts
@@ -44,4 +44,30 @@ describe("multimodal judge provider factory", () => {
       }),
     ).toThrow("Multimodal judge provider configuration is incomplete");
   });
+
+  it("wraps OpenRouter primary with a Hetzner transport fallback", () => {
+    const provider = createMultimodalJudgeProvider({
+      MULTIMODAL_JUDGE_PROVIDER: "openrouter",
+      JUDGE_BASE_URL: "https://openrouter.example.test/api/v1",
+      JUDGE_API_KEY: "openrouter-multimodal-api-key",
+      JUDGE_MODEL: "xiaomi/mimo-v2.5",
+      JUDGE_FALLBACK_MODEL: "xiaomi/mimo-v2.5",
+      JUDGE_TRANSPORT_FALLBACK_BASE_URL:
+        "https://inference.example.test/api/v1",
+      JUDGE_TRANSPORT_FALLBACK_API_KEY: "hetzner-multimodal-api-key",
+      JUDGE_TRANSPORT_FALLBACK_MODEL: "hetzner-judge",
+      JUDGE_TRANSPORT_FALLBACK_VISION_MODEL: "hetzner-vision",
+    });
+
+    expect(provider.descriptor).toEqual({
+      provider: "openrouter",
+      model: "xiaomi/mimo-v2.5",
+      visionModel: "xiaomi/mimo-v2.5",
+    });
+    expect(provider.transportFallbackDescriptor).toEqual({
+      provider: "hetzner-inference",
+      model: "hetzner-judge",
+      visionModel: "hetzner-vision",
+    });
+  });
 });

--- a/apps/worker/src/multimodal-provider-factory.ts
+++ b/apps/worker/src/multimodal-provider-factory.ts
@@ -2,6 +2,7 @@ import type { WorkerConfig } from "@slopproof/config";
 import {
   HetznerMultimodalJudgeProvider,
   LocalFakeInlineMultimodalJudgeProvider,
+  TransportFallbackMultimodalJudgeProvider,
   type HetznerMultimodalJudgeDependencies,
   type InlineMultimodalJudgeProvider,
 } from "@slopproof/providers";
@@ -19,6 +20,10 @@ export function createMultimodalJudgeProvider(
     | "JUDGE_API_KEY"
     | "JUDGE_MODEL"
     | "JUDGE_FALLBACK_MODEL"
+    | "JUDGE_TRANSPORT_FALLBACK_BASE_URL"
+    | "JUDGE_TRANSPORT_FALLBACK_API_KEY"
+    | "JUDGE_TRANSPORT_FALLBACK_MODEL"
+    | "JUDGE_TRANSPORT_FALLBACK_VISION_MODEL"
   >,
   dependencies: MultimodalProviderFactoryDependencies = {},
 ): InlineMultimodalJudgeProvider {
@@ -27,14 +32,37 @@ export function createMultimodalJudgeProvider(
       dependencies.clock ?? { now: () => new Date() },
     );
   }
-  return new HetznerMultimodalJudgeProvider(
+  const primary = new HetznerMultimodalJudgeProvider(
     {
+      provider:
+        config.MULTIMODAL_JUDGE_PROVIDER === "openrouter"
+          ? "openrouter"
+          : "hetzner-inference",
       baseUrl: required(config.JUDGE_BASE_URL),
       apiKey: required(config.JUDGE_API_KEY),
       model: required(config.JUDGE_MODEL),
       visionModel: required(config.JUDGE_FALLBACK_MODEL),
     },
     dependencies.hetzner,
+  );
+  if (
+    config.MULTIMODAL_JUDGE_PROVIDER !== "openrouter" ||
+    config.JUDGE_TRANSPORT_FALLBACK_BASE_URL === undefined
+  ) {
+    return primary;
+  }
+  return new TransportFallbackMultimodalJudgeProvider(
+    primary,
+    new HetznerMultimodalJudgeProvider(
+      {
+        provider: "hetzner-inference",
+        baseUrl: required(config.JUDGE_TRANSPORT_FALLBACK_BASE_URL),
+        apiKey: required(config.JUDGE_TRANSPORT_FALLBACK_API_KEY),
+        model: required(config.JUDGE_TRANSPORT_FALLBACK_MODEL),
+        visionModel: required(config.JUDGE_TRANSPORT_FALLBACK_VISION_MODEL),
+      },
+      dependencies.hetzner,
+    ),
   );
 }
 

--- a/apps/worker/src/semantic-generation.test.ts
+++ b/apps/worker/src/semantic-generation.test.ts
@@ -81,6 +81,32 @@ describe("Gate 4 worker-only semantic generation", () => {
     expect(providerInput?.inputVersion).toBe("learning-material-input-v1");
     expect(JSON.stringify(providerInput)).not.toContain(context.revisionId);
     expect(JSON.stringify(providerInput)).not.toContain(context.headSha);
+    expect(first.providerMetadata.provider).toBe("local-contract-test");
+  });
+
+  it("persists the provider that actually answered after a transport hop", async () => {
+    const context = contextFixture();
+    const provider = new StubSemanticProvider({
+      initial: () => ({
+        ...response(deterministicLearningFallbackV1(context, 3)),
+        answeredBy: {
+          provider: "hetzner-inference",
+          model: "hetzner-learning",
+        },
+      }),
+      repair: () => {
+        throw new Error("repair must not run for valid output");
+      },
+    });
+
+    const result = await serviceWith(provider).generateLearningBundle(
+      learningRequest(context, 3),
+    );
+
+    expect(result.providerMetadata.outcome).toBe("generated");
+    expect(result.providerMetadata.provider).toBe("hetzner-inference");
+    expect(result.providerMetadata.model).toBe("hetzner-learning");
+    expect(provider.descriptor.provider).toBe("local-contract-test");
   });
 
   it("repairs invalid Proof output once and freezes exactly the analyzer budget", async () => {

--- a/apps/worker/src/semantic-generation.ts
+++ b/apps/worker/src/semantic-generation.ts
@@ -378,6 +378,7 @@ async function invokeWithOneRepair<
   let repairEligible = false;
   let knownTransportAttemptCount: number | null = null;
   let failure: SemanticProviderFailureV1 | undefined;
+  let answeredBy = descriptor.success ? descriptor.data : undefined;
 
   if (
     descriptor.success &&
@@ -401,8 +402,12 @@ async function invokeWithOneRepair<
         );
       }
       rejectedOutput = response.success ? response.data.output : rawResponse;
-      if (response.success)
+      if (response.success) {
         tokenUsage = addUsage(tokenUsage, response.data.tokenUsage);
+        if (response.data.answeredBy !== undefined) {
+          answeredBy = response.data.answeredBy;
+        }
+      }
       if (!response.success) {
         throw new SemanticContentValidationError("schema_invalid");
       }
@@ -447,8 +452,12 @@ async function invokeWithOneRepair<
             repair.data.transportAttemptCount,
           );
         }
-        if (repair.success)
+        if (repair.success) {
           tokenUsage = addUsage(tokenUsage, repair.data.tokenUsage);
+          if (repair.data.answeredBy !== undefined) {
+            answeredBy = repair.data.answeredBy;
+          }
+        }
         if (!repair.success) {
           throw new SemanticContentValidationError("schema_invalid");
         }
@@ -492,9 +501,15 @@ async function invokeWithOneRepair<
         : semanticValidationFailure(knownTransportAttemptCount);
   }
   const completedAt = input.clock.now();
-  const safeDescriptor = descriptor.success
-    ? descriptor.data
-    : { provider: "unavailable", model: "unavailable" };
+  const safeDescriptor =
+    outcome === "fallback"
+      ? descriptor.success
+        ? descriptor.data
+        : { provider: "unavailable", model: "unavailable" }
+      : (answeredBy ??
+        (descriptor.success
+          ? descriptor.data
+          : { provider: "unavailable", model: "unavailable" }));
   const metadata = SemanticProviderInvocationMetadataV1Schema.parse({
     schemaVersion: "1",
     metadataVersion: "semantic-provider-metadata-v1",

--- a/apps/worker/src/semantic-provider-factory.test.ts
+++ b/apps/worker/src/semantic-provider-factory.test.ts
@@ -57,4 +57,31 @@ describe("semantic provider factory", () => {
       }),
     ).toThrow("Semantic provider configuration is incomplete");
   });
+
+  it("wraps OpenRouter primary with a Hetzner transport fallback", () => {
+    const providers = createSemanticProviderSet({
+      GENERATION_PROVIDER: "openrouter",
+      GENERATION_BASE_URL: "https://openrouter.example.test/api/v1",
+      GENERATION_API_KEY: "openrouter-provider-secret",
+      LEARNING_MODEL: "xiaomi/mimo-v2.5",
+      PRACTICE_MODEL: "xiaomi/mimo-v2.5",
+      PROOF_QUESTION_MODEL: "xiaomi/mimo-v2.5",
+      GENERATION_FALLBACK_BASE_URL: "https://inference.example.test/api/v1",
+      GENERATION_FALLBACK_API_KEY: "hetzner-provider-secret",
+      LEARNING_FALLBACK_MODEL: "hetzner-learning",
+      PRACTICE_FALLBACK_MODEL: "hetzner-practice",
+      PROOF_QUESTION_FALLBACK_MODEL: "hetzner-proof",
+    });
+
+    expect(providers.learningMaterialProvider.descriptor).toEqual({
+      provider: "openrouter",
+      model: "xiaomi/mimo-v2.5",
+    });
+    expect(providers.practiceCoachProvider.descriptor.model).toBe(
+      "xiaomi/mimo-v2.5",
+    );
+    expect(providers.proofQuestionProvider.descriptor.provider).toBe(
+      "openrouter",
+    );
+  });
 });

--- a/apps/worker/src/semantic-provider-factory.ts
+++ b/apps/worker/src/semantic-provider-factory.ts
@@ -6,6 +6,7 @@ import {
   LocalFakeLearningMaterialProvider,
   LocalFakePracticeCoachProvider,
   LocalFakeProofQuestionProvider,
+  TransportFallbackSemanticProvider,
   type HetznerSemanticProviderDependencies,
   type LearningMaterialProvider,
   type PracticeCoachProvider,
@@ -36,6 +37,11 @@ export function createSemanticProviderSet(
     | "LEARNING_MODEL"
     | "PRACTICE_MODEL"
     | "PROOF_QUESTION_MODEL"
+    | "GENERATION_FALLBACK_BASE_URL"
+    | "GENERATION_FALLBACK_API_KEY"
+    | "LEARNING_FALLBACK_MODEL"
+    | "PRACTICE_FALLBACK_MODEL"
+    | "PROOF_QUESTION_FALLBACK_MODEL"
   >,
   dependencies: SemanticProviderFactoryDependencies = {},
 ): SemanticProviderSet {
@@ -47,21 +53,76 @@ export function createSemanticProviderSet(
       proofQuestionProvider: new LocalFakeProofQuestionProvider(clock),
     };
   }
-  const baseUrl = required(config.GENERATION_BASE_URL);
-  const apiKey = required(config.GENERATION_API_KEY);
-  const shared = { baseUrl, apiKey };
+  const primary = createCompatibleSemanticSet(
+    config.GENERATION_PROVIDER === "openrouter"
+      ? "openrouter"
+      : "hetzner-inference",
+    {
+      baseUrl: required(config.GENERATION_BASE_URL),
+      apiKey: required(config.GENERATION_API_KEY),
+      learningModel: required(config.LEARNING_MODEL),
+      practiceModel: required(config.PRACTICE_MODEL),
+      proofModel: required(config.PROOF_QUESTION_MODEL),
+    },
+    dependencies.hetzner,
+  );
+  if (config.GENERATION_PROVIDER !== "openrouter") return primary;
+  if (config.GENERATION_FALLBACK_BASE_URL === undefined) return primary;
+  const fallback = createCompatibleSemanticSet(
+    "hetzner-inference",
+    {
+      baseUrl: required(config.GENERATION_FALLBACK_BASE_URL),
+      apiKey: required(config.GENERATION_FALLBACK_API_KEY),
+      learningModel: required(config.LEARNING_FALLBACK_MODEL),
+      practiceModel: required(config.PRACTICE_FALLBACK_MODEL),
+      proofModel: required(config.PROOF_QUESTION_FALLBACK_MODEL),
+    },
+    dependencies.hetzner,
+  );
+  return {
+    learningMaterialProvider: new TransportFallbackSemanticProvider(
+      primary.learningMaterialProvider,
+      fallback.learningMaterialProvider,
+    ),
+    practiceCoachProvider: new TransportFallbackSemanticProvider(
+      primary.practiceCoachProvider,
+      fallback.practiceCoachProvider,
+    ),
+    proofQuestionProvider: new TransportFallbackSemanticProvider(
+      primary.proofQuestionProvider,
+      fallback.proofQuestionProvider,
+    ),
+  };
+}
+
+function createCompatibleSemanticSet(
+  provider: "hetzner-inference" | "openrouter",
+  models: {
+    baseUrl: string;
+    apiKey: string;
+    learningModel: string;
+    practiceModel: string;
+    proofModel: string;
+  },
+  dependencies?: HetznerSemanticProviderDependencies,
+): SemanticProviderSet {
+  const shared = {
+    provider,
+    baseUrl: models.baseUrl,
+    apiKey: models.apiKey,
+  };
   return {
     learningMaterialProvider: new HetznerLearningMaterialProvider(
-      { ...shared, model: required(config.LEARNING_MODEL) },
-      dependencies.hetzner,
+      { ...shared, model: models.learningModel },
+      dependencies,
     ),
     practiceCoachProvider: new HetznerPracticeCoachProvider(
-      { ...shared, model: required(config.PRACTICE_MODEL) },
-      dependencies.hetzner,
+      { ...shared, model: models.practiceModel },
+      dependencies,
     ),
     proofQuestionProvider: new HetznerProofQuestionProvider(
-      { ...shared, model: required(config.PROOF_QUESTION_MODEL) },
-      dependencies.hetzner,
+      { ...shared, model: models.proofModel },
+      dependencies,
     ),
   };
 }

--- a/docs/operations/production-configuration.md
+++ b/docs/operations/production-configuration.md
@@ -164,15 +164,19 @@ refuse to run unless the operator explicitly sets `LIVE_SMOKE=1`:
 LIVE_SMOKE=1 node scripts/live-smoke-hetzner-text-json.mjs
 LIVE_SMOKE=1 node scripts/live-smoke-hetzner-vision.mjs
 LIVE_SMOKE=1 node scripts/live-smoke-openrouter-stt.mjs
+LIVE_SMOKE=1 node scripts/live-smoke-openrouter-mimo.mjs
 ```
 
 They use only the canonical provider variables already loaded in the shell.
 Each check has bounded fixtures, request and overall deadlines, bounded response
 bodies, at most three transport attempts, and retry only for rate limits,
 server failures, network failures or timeouts. Hetzner checks disable tools and
-request `store=false`; OpenRouter receives a one-second in-memory WAV and also
-gets `store=false`. Output is limited to a provider name and a safe pass/failure
-class; model responses and provider error bodies are never logged.
+request `store=false`; the OpenRouter MiMo check uses the streamed generation
+wire (`stream=true`, `Accept: text/event-stream`, `response_format.json_schema`)
+and `store=false`, and does not hop to Hetzner; OpenRouter STT receives a
+one-second in-memory WAV and also gets `store=false`. Output is limited to a
+provider name and a safe pass/failure class; model responses and provider error
+bodies are never logged.
 
 Contract tests are non-networked:
 

--- a/docs/operations/production-configuration.md
+++ b/docs/operations/production-configuration.md
@@ -139,6 +139,22 @@ environment. Gate 7 must mount only the process-specific result and the exact
 key files. It must not place values in Compose YAML, image layers or build
 arguments.
 
+## Generation and judge providers
+
+Production generation and the multimodal judge may be compiled as either:
+
+- `hetzner` only, using `GENERATION_*` / `JUDGE_*` against one inference URL;
+- `openrouter` primary plus a separate Hetzner transport fallback.
+
+`JUDGE_FALLBACK_MODEL` remains the same-URL vision model for the primary
+judge client. It is not the Hetzner hop. The hop uses
+`GENERATION_FALLBACK_*` and `JUDGE_TRANSPORT_FALLBACK_*` so the compiler
+cannot point one Hetzner client at OpenRouter and lose a real fallback.
+Hetzner is used only after timeout, 5xx, network, unavailable, or
+rate-limit failures. Invalid model output stays on the provider that
+produced it. Persisted provider/model metadata names the provider that
+answered. Transcription stays OpenRouter Whisper.
+
 ## Provider capability checks
 
 The following scripts make real, potentially billable requests and therefore

--- a/packages/config/src/index.test.ts
+++ b/packages/config/src/index.test.ts
@@ -183,6 +183,11 @@ describe("process-scoped configuration", () => {
       "GENERATION_PROVIDER",
     ],
     [
+      "openrouter generation",
+      { GENERATION_PROVIDER: "openrouter" },
+      "GENERATION_PROVIDER",
+    ],
+    [
       "real transcription",
       { TRANSCRIPTION_PROVIDER: "openrouter" },
       "TRANSCRIPTION_PROVIDER",
@@ -307,6 +312,108 @@ describe("process-scoped configuration", () => {
     expect(config.TRANSCRIPTION_PROVIDER).toBe("openrouter");
     expect(config.MULTIMODAL_JUDGE_PROVIDER).toBe("hetzner");
     expect(config).not.toHaveProperty("GITHUB_CLIENT_SECRET");
+  });
+
+  it("accepts OpenRouter-primary generation and judge with Hetzner transport fallback", () => {
+    const config = loadWorkerConfig({
+      ...productionCore,
+      ...productionStorage,
+      ...productionWorkerRuntime,
+      GITHUB_ADAPTER: "octokit",
+      KEY_WRAPPING_PROVIDER: "local",
+      KEY_WRAPPING_PRIVATE_KEY_PATH: "/host/secrets/wrapping-private.pem",
+      KEY_WRAPPING_PRIVATE_KEY_CONTAINER_PATH:
+        "/run/secrets/wrapping-private.pem",
+      WORKER_INTERNAL_SECRET: "i".repeat(48),
+      PROVIDER_PAYLOAD_KEY_BASE64: Buffer.alloc(32, 112).toString("base64"),
+      GENERATION_PROVIDER: "openrouter",
+      GENERATION_BASE_URL: "https://openrouter.ai/api/v1",
+      GENERATION_API_KEY: "g".repeat(40),
+      LEARNING_MODEL: "xiaomi/mimo-v2.5",
+      PRACTICE_MODEL: "xiaomi/mimo-v2.5",
+      PROOF_QUESTION_MODEL: "xiaomi/mimo-v2.5",
+      GENERATION_FALLBACK_BASE_URL: "https://inference.example/api/v1",
+      GENERATION_FALLBACK_API_KEY: "h".repeat(40),
+      LEARNING_FALLBACK_MODEL: "hetzner-learning",
+      PRACTICE_FALLBACK_MODEL: "hetzner-practice",
+      PROOF_QUESTION_FALLBACK_MODEL: "hetzner-proof",
+      TRANSCRIPTION_PROVIDER: "openrouter",
+      TRANSCRIPTION_BASE_URL: "https://transcription.example/api/v1",
+      TRANSCRIPTION_API_KEY: "t".repeat(40),
+      TRANSCRIPTION_MODEL: "transcription-model",
+      MULTIMODAL_JUDGE_PROVIDER: "openrouter",
+      JUDGE_BASE_URL: "https://openrouter.ai/api/v1",
+      JUDGE_API_KEY: "j".repeat(40),
+      JUDGE_MODEL: "xiaomi/mimo-v2.5",
+      JUDGE_FALLBACK_MODEL: "xiaomi/mimo-v2.5",
+      JUDGE_TRANSPORT_FALLBACK_BASE_URL: "https://inference.example/api/v1",
+      JUDGE_TRANSPORT_FALLBACK_API_KEY: "k".repeat(40),
+      JUDGE_TRANSPORT_FALLBACK_MODEL: "hetzner-judge",
+      JUDGE_TRANSPORT_FALLBACK_VISION_MODEL: "hetzner-vision",
+    });
+
+    expect(config.GENERATION_PROVIDER).toBe("openrouter");
+    expect(config.MULTIMODAL_JUDGE_PROVIDER).toBe("openrouter");
+    expect(config.LEARNING_MODEL).toBe("xiaomi/mimo-v2.5");
+    expect(config.GENERATION_FALLBACK_BASE_URL).toBe(
+      "https://inference.example/api/v1",
+    );
+    expect(config.JUDGE_TRANSPORT_FALLBACK_MODEL).toBe("hetzner-judge");
+  });
+
+  it("rejects production OpenRouter generation without a Hetzner transport fallback", () => {
+    expectConfigurationFields(
+      () =>
+        loadWorkerConfig({
+          ...productionCore,
+          ...productionStorage,
+          ...productionWorkerRuntime,
+          GITHUB_ADAPTER: "octokit",
+          KEY_WRAPPING_PROVIDER: "local",
+          KEY_WRAPPING_PRIVATE_KEY_PATH: "/host/secrets/wrapping-private.pem",
+          KEY_WRAPPING_PRIVATE_KEY_CONTAINER_PATH:
+            "/run/secrets/wrapping-private.pem",
+          WORKER_INTERNAL_SECRET: "i".repeat(48),
+          PROVIDER_PAYLOAD_KEY_BASE64: Buffer.alloc(32, 112).toString("base64"),
+          GENERATION_PROVIDER: "openrouter",
+          GENERATION_BASE_URL: "https://openrouter.ai/api/v1",
+          GENERATION_API_KEY: "g".repeat(40),
+          LEARNING_MODEL: "xiaomi/mimo-v2.5",
+          PRACTICE_MODEL: "xiaomi/mimo-v2.5",
+          PROOF_QUESTION_MODEL: "xiaomi/mimo-v2.5",
+          TRANSCRIPTION_PROVIDER: "openrouter",
+          TRANSCRIPTION_BASE_URL: "https://transcription.example/api/v1",
+          TRANSCRIPTION_API_KEY: "t".repeat(40),
+          TRANSCRIPTION_MODEL: "transcription-model",
+          MULTIMODAL_JUDGE_PROVIDER: "hetzner",
+          JUDGE_BASE_URL: "https://inference.example/api/v1",
+          JUDGE_API_KEY: "j".repeat(40),
+          JUDGE_MODEL: "judge-model",
+          JUDGE_FALLBACK_MODEL: "vision-model",
+        }),
+      "GENERATION_FALLBACK_BASE_URL",
+      "GENERATION_FALLBACK_API_KEY",
+      "LEARNING_FALLBACK_MODEL",
+      "PRACTICE_FALLBACK_MODEL",
+      "PROOF_QUESTION_FALLBACK_MODEL",
+    );
+  });
+
+  it("rejects leftover Hetzner fallback fields when generation stays Hetzner-only", () => {
+    expectConfigurationFields(
+      () =>
+        loadWorkerConfig({
+          ...localWorker,
+          GENERATION_PROVIDER: "hetzner",
+          GENERATION_BASE_URL: "https://inference.example/api/v1",
+          GENERATION_API_KEY: "g".repeat(40),
+          LEARNING_MODEL: "text-model",
+          PRACTICE_MODEL: "text-model",
+          PROOF_QUESTION_MODEL: "text-model",
+          GENERATION_FALLBACK_BASE_URL: "https://inference.example/api/v1",
+        }),
+      "GENERATION_FALLBACK_BASE_URL",
+    );
   });
 
   it.each([

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -4,9 +4,17 @@ import { z } from "zod";
 
 export const DeploymentProfileSchema = z.enum(["local", "production"]);
 export const GithubAdapterSchema = z.enum(["fake", "octokit"]);
-export const GenerationProviderSchema = z.enum(["fake", "hetzner"]);
+export const GenerationProviderSchema = z.enum([
+  "fake",
+  "hetzner",
+  "openrouter",
+]);
 export const TranscriptionProviderSchema = z.enum(["fake", "openrouter"]);
-export const MultimodalJudgeProviderSchema = z.enum(["fake", "hetzner"]);
+export const MultimodalJudgeProviderSchema = z.enum([
+  "fake",
+  "hetzner",
+  "openrouter",
+]);
 
 const booleanFromEnv = z
   .enum(["true", "false"])
@@ -176,6 +184,11 @@ const workerSchema = z
     LEARNING_MODEL: z.string().trim().min(1).optional(),
     PRACTICE_MODEL: z.string().trim().min(1).optional(),
     PROOF_QUESTION_MODEL: z.string().trim().min(1).optional(),
+    GENERATION_FALLBACK_BASE_URL: z.url().optional(),
+    GENERATION_FALLBACK_API_KEY: z.string().min(16).optional(),
+    LEARNING_FALLBACK_MODEL: z.string().trim().min(1).optional(),
+    PRACTICE_FALLBACK_MODEL: z.string().trim().min(1).optional(),
+    PROOF_QUESTION_FALLBACK_MODEL: z.string().trim().min(1).optional(),
     TRANSCRIPTION_PROVIDER: TranscriptionProviderSchema.default("fake"),
     TRANSCRIPTION_BASE_URL: z.url().optional(),
     TRANSCRIPTION_API_KEY: z.string().min(16).optional(),
@@ -185,6 +198,20 @@ const workerSchema = z
     JUDGE_API_KEY: z.string().min(16).optional(),
     JUDGE_MODEL: z.string().trim().min(1).max(100).optional(),
     JUDGE_FALLBACK_MODEL: z.string().trim().min(1).max(100).optional(),
+    JUDGE_TRANSPORT_FALLBACK_BASE_URL: z.url().optional(),
+    JUDGE_TRANSPORT_FALLBACK_API_KEY: z.string().min(16).optional(),
+    JUDGE_TRANSPORT_FALLBACK_MODEL: z
+      .string()
+      .trim()
+      .min(1)
+      .max(100)
+      .optional(),
+    JUDGE_TRANSPORT_FALLBACK_VISION_MODEL: z
+      .string()
+      .trim()
+      .min(1)
+      .max(100)
+      .optional(),
     WORKER_HOST: z.string().trim().min(1).default("127.0.0.1"),
     WORKER_PORT: z.coerce.number().int().min(1).max(65_535).default(4001),
     FFMPEG_PATH: z.string().min(1).default("ffmpeg"),
@@ -217,15 +244,21 @@ const workerSchema = z
     requireValue(context, value.GITHUB_ADAPTER === "octokit", [
       "GITHUB_ADAPTER",
     ]);
-    requireValue(context, value.GENERATION_PROVIDER === "hetzner", [
-      "GENERATION_PROVIDER",
-    ]);
+    requireValue(
+      context,
+      value.GENERATION_PROVIDER === "hetzner" ||
+        value.GENERATION_PROVIDER === "openrouter",
+      ["GENERATION_PROVIDER"],
+    );
     requireValue(context, value.TRANSCRIPTION_PROVIDER === "openrouter", [
       "TRANSCRIPTION_PROVIDER",
     ]);
-    requireValue(context, value.MULTIMODAL_JUDGE_PROVIDER === "hetzner", [
-      "MULTIMODAL_JUDGE_PROVIDER",
-    ]);
+    requireValue(
+      context,
+      value.MULTIMODAL_JUDGE_PROVIDER === "hetzner" ||
+        value.MULTIMODAL_JUDGE_PROVIDER === "openrouter",
+      ["MULTIMODAL_JUDGE_PROVIDER"],
+    );
     requireProductionS3Identity(context, value);
     requireSafeSecret(
       context,
@@ -388,11 +421,29 @@ function refineKeyWrapping(
   requireValue(context, Boolean(value.KMS_KEY_ID), ["KMS_KEY_ID"]);
 }
 
+const generationFallbackFields = [
+  "GENERATION_FALLBACK_BASE_URL",
+  "GENERATION_FALLBACK_API_KEY",
+  "LEARNING_FALLBACK_MODEL",
+  "PRACTICE_FALLBACK_MODEL",
+  "PROOF_QUESTION_FALLBACK_MODEL",
+] as const;
+
+const judgeTransportFallbackFields = [
+  "JUDGE_TRANSPORT_FALLBACK_BASE_URL",
+  "JUDGE_TRANSPORT_FALLBACK_API_KEY",
+  "JUDGE_TRANSPORT_FALLBACK_MODEL",
+  "JUDGE_TRANSPORT_FALLBACK_VISION_MODEL",
+] as const;
+
 function refineGenerationProvider(
   value: z.output<typeof workerSchema>,
   context: z.RefinementCtx,
 ): void {
-  if (value.GENERATION_PROVIDER === "fake") return;
+  if (value.GENERATION_PROVIDER === "fake") {
+    rejectPresentFields(context, value, generationFallbackFields);
+    return;
+  }
   requireProviderEndpoint(
     context,
     value.GENERATION_BASE_URL,
@@ -410,6 +461,16 @@ function refineGenerationProvider(
   ] as const) {
     requireValue(context, Boolean(value[field]), [field]);
   }
+  if (value.GENERATION_PROVIDER !== "openrouter") {
+    rejectPresentFields(context, value, generationFallbackFields);
+    return;
+  }
+  refineTransportFallbackFields(
+    context,
+    value,
+    generationFallbackFields,
+    isProduction(value),
+  );
 }
 
 function refineTranscriptionProvider(
@@ -436,13 +497,71 @@ function refineJudgeProvider(
   value: z.output<typeof workerSchema>,
   context: z.RefinementCtx,
 ): void {
-  if (value.MULTIMODAL_JUDGE_PROVIDER === "fake") return;
+  if (value.MULTIMODAL_JUDGE_PROVIDER === "fake") {
+    rejectPresentFields(context, value, judgeTransportFallbackFields);
+    return;
+  }
   requireProviderEndpoint(context, value.JUDGE_BASE_URL, "JUDGE_BASE_URL");
   requireProviderSecret(context, value.JUDGE_API_KEY, "JUDGE_API_KEY");
   requireValue(context, Boolean(value.JUDGE_MODEL), ["JUDGE_MODEL"]);
   requireValue(context, Boolean(value.JUDGE_FALLBACK_MODEL), [
     "JUDGE_FALLBACK_MODEL",
   ]);
+  if (value.MULTIMODAL_JUDGE_PROVIDER !== "openrouter") {
+    rejectPresentFields(context, value, judgeTransportFallbackFields);
+    return;
+  }
+  refineTransportFallbackFields(
+    context,
+    value,
+    judgeTransportFallbackFields,
+    isProduction(value),
+  );
+}
+
+function refineTransportFallbackFields(
+  context: z.RefinementCtx,
+  value: z.output<typeof workerSchema>,
+  fields: readonly (keyof z.output<typeof workerSchema>)[],
+  required: boolean,
+): void {
+  const present = fields.filter((field) => Boolean(value[field]));
+  if (!required && present.length === 0) return;
+  for (const field of fields) {
+    const fieldName = String(field);
+    const fieldValue = value[field];
+    if (fieldName.endsWith("BASE_URL")) {
+      requireProviderEndpoint(
+        context,
+        typeof fieldValue === "string" ? fieldValue : undefined,
+        fieldName,
+      );
+      continue;
+    }
+    if (fieldName.endsWith("API_KEY")) {
+      requireProviderSecret(
+        context,
+        typeof fieldValue === "string" ? fieldValue : undefined,
+        fieldName,
+      );
+      continue;
+    }
+    requireValue(
+      context,
+      typeof fieldValue === "string" && fieldValue.length > 0,
+      [fieldName],
+    );
+  }
+}
+
+function rejectPresentFields(
+  context: z.RefinementCtx,
+  value: z.output<typeof workerSchema>,
+  fields: readonly (keyof z.output<typeof workerSchema>)[],
+): void {
+  for (const field of fields) {
+    if (Boolean(value[field])) requireValue(context, false, [field]);
+  }
 }
 
 function isProduction(value: { DEPLOYMENT_PROFILE: string }): boolean {
@@ -717,7 +836,9 @@ const baseForbiddenProductionFields = [
   "WORKER_INTERNAL_SECRET",
   "PROVIDER_PAYLOAD_KEY_BASE64",
   "GENERATION_API_KEY",
+  "GENERATION_FALLBACK_API_KEY",
   "JUDGE_API_KEY",
+  "JUDGE_TRANSPORT_FALLBACK_API_KEY",
   "TRANSCRIPTION_API_KEY",
   "GITHUB_WEBHOOK_SECRET",
   "GITHUB_CLIENT_SECRET",
@@ -731,7 +852,9 @@ const webForbiddenProductionFields = [
   ...forbiddenEverywhereInProduction,
   "PROVIDER_PAYLOAD_KEY_BASE64",
   "GENERATION_API_KEY",
+  "GENERATION_FALLBACK_API_KEY",
   "JUDGE_API_KEY",
+  "JUDGE_TRANSPORT_FALLBACK_API_KEY",
   "TRANSCRIPTION_API_KEY",
   "KEY_WRAPPING_PRIVATE_KEY_PATH",
   "KEY_WRAPPING_PRIVATE_KEY_CONTAINER_PATH",
@@ -760,7 +883,9 @@ const githubControlForbiddenProductionFields = [
   "WORKER_INTERNAL_SECRET",
   "PROVIDER_PAYLOAD_KEY_BASE64",
   "GENERATION_API_KEY",
+  "GENERATION_FALLBACK_API_KEY",
   "JUDGE_API_KEY",
+  "JUDGE_TRANSPORT_FALLBACK_API_KEY",
   "TRANSCRIPTION_API_KEY",
   "GITHUB_WEBHOOK_SECRET",
   "GITHUB_CLIENT_ID",
@@ -816,11 +941,20 @@ const workerEnvironmentFileFields = [
   "LEARNING_MODEL",
   "PRACTICE_MODEL",
   "PROOF_QUESTION_MODEL",
+  "GENERATION_FALLBACK_BASE_URL",
+  "GENERATION_FALLBACK_API_KEY",
+  "LEARNING_FALLBACK_MODEL",
+  "PRACTICE_FALLBACK_MODEL",
+  "PROOF_QUESTION_FALLBACK_MODEL",
   "MULTIMODAL_JUDGE_PROVIDER",
   "JUDGE_BASE_URL",
   "JUDGE_API_KEY",
   "JUDGE_MODEL",
   "JUDGE_FALLBACK_MODEL",
+  "JUDGE_TRANSPORT_FALLBACK_BASE_URL",
+  "JUDGE_TRANSPORT_FALLBACK_API_KEY",
+  "JUDGE_TRANSPORT_FALLBACK_MODEL",
+  "JUDGE_TRANSPORT_FALLBACK_VISION_MODEL",
   "TRANSCRIPTION_PROVIDER",
   "TRANSCRIPTION_BASE_URL",
   "TRANSCRIPTION_API_KEY",

--- a/packages/providers/src/errors.ts
+++ b/packages/providers/src/errors.ts
@@ -56,3 +56,33 @@ export class ProviderError extends Error {
     this.telemetry = options?.telemetry;
   }
 }
+
+const TRANSPORT_FAILURE_KINDS = new Set<ProviderFailureKind>([
+  "deadline_exceeded",
+  "network",
+  "rate_limited",
+  "timeout",
+  "upstream_unavailable",
+]);
+
+/**
+ * Cross-provider hops are allowed only after a transport failure. Schema
+ * rejects, invalid model output, and terminal 4xx request rejections stay on
+ * the provider that produced them.
+ */
+export function isTransportFailure(error: unknown): boolean {
+  if (!(error instanceof ProviderError)) return false;
+  if (
+    error.code === "INVALID_OUTPUT" ||
+    error.code === "INVALID_INPUT" ||
+    error.disposition === "terminal" ||
+    error.disposition === "review"
+  ) {
+    return false;
+  }
+  const kind = error.telemetry?.lastFailureKind;
+  if (kind !== undefined && !TRANSPORT_FAILURE_KINDS.has(kind)) return false;
+  return (
+    error.code === "DEADLINE_EXCEEDED" || error.code === "PROVIDER_UNAVAILABLE"
+  );
+}

--- a/packages/providers/src/hetzner-multimodal.ts
+++ b/packages/providers/src/hetzner-multimodal.ts
@@ -363,6 +363,7 @@ export type InlineMultimodalJudgeDescriptorV1 = z.infer<
 
 export interface InlineMultimodalJudgeProvider {
   readonly descriptor: InlineMultimodalJudgeDescriptorV1;
+  readonly transportFallbackDescriptor?: InlineMultimodalJudgeDescriptorV1;
   evaluate(
     input: MultimodalJudgeProviderInputV1,
     context: ProviderContextV1,
@@ -371,6 +372,9 @@ export interface InlineMultimodalJudgeProvider {
 
 export const HetznerMultimodalJudgeConfigV1Schema = z
   .object({
+    provider: z
+      .enum(["hetzner-inference", "openrouter"])
+      .default("hetzner-inference"),
     baseUrl: z.url().refine(isSafeProviderBaseUrl),
     apiKey: z
       .string()
@@ -382,7 +386,7 @@ export const HetznerMultimodalJudgeConfigV1Schema = z
   })
   .strict();
 
-export type HetznerMultimodalJudgeConfigV1 = z.infer<
+export type HetznerMultimodalJudgeConfigV1 = z.input<
   typeof HetznerMultimodalJudgeConfigV1Schema
 >;
 
@@ -467,7 +471,7 @@ export class HetznerMultimodalJudgeProvider implements InlineMultimodalJudgeProv
     this.endpoint = chatCompletionsEndpoint(config.data.baseUrl);
     this.apiKey = config.data.apiKey;
     this.descriptor = InlineMultimodalJudgeDescriptorV1Schema.parse({
-      provider: "hetzner-inference",
+      provider: config.data.provider,
       model: config.data.model,
       visionModel: config.data.visionModel,
     });
@@ -804,28 +808,43 @@ export function validateMultimodalJudgeProviderResultV1(
 ): MultimodalJudgeProviderResultV1 {
   const result = MultimodalJudgeProviderResultV1Schema.safeParse(rawResult);
   const input = MultimodalJudgeProviderInputV1Schema.safeParse(rawInput);
-  const descriptor =
-    InlineMultimodalJudgeDescriptorV1Schema.safeParse(rawDescriptor);
-  if (!result.success || !input.success || !descriptor.success) {
+  const descriptors = normalizeJudgeDescriptors(rawDescriptor);
+  if (!result.success || !input.success || descriptors === undefined) {
     throw invalidOutputError();
   }
   const candidate = validateMultimodalJudgeCandidateV1(
     result.data.candidate,
     input.data,
   );
-  const expectedModels = new Set([
-    descriptor.data.model,
-    descriptor.data.visionModel,
-  ]);
   if (
-    result.data.metadata.provider !== descriptor.data.provider ||
-    !expectedModels.has(result.data.metadata.model) ||
     result.data.metadata.inputHash !== hashProviderInput(input.data) ||
     result.data.metadata.outputHash !== hashUnknown(candidate)
   ) {
     throw invalidOutputError();
   }
+  const accepted = descriptors.some((descriptor) => {
+    const expectedModels = new Set([descriptor.model, descriptor.visionModel]);
+    return (
+      result.data.metadata.provider === descriptor.provider &&
+      expectedModels.has(result.data.metadata.model)
+    );
+  });
+  if (!accepted) throw invalidOutputError();
   return { candidate, metadata: result.data.metadata };
+}
+
+function normalizeJudgeDescriptors(
+  rawDescriptor: unknown,
+): InlineMultimodalJudgeDescriptorV1[] | undefined {
+  const values = Array.isArray(rawDescriptor) ? rawDescriptor : [rawDescriptor];
+  if (values.length === 0 || values.length > 2) return undefined;
+  const descriptors: InlineMultimodalJudgeDescriptorV1[] = [];
+  for (const value of values) {
+    const parsed = InlineMultimodalJudgeDescriptorV1Schema.safeParse(value);
+    if (!parsed.success) return undefined;
+    descriptors.push(parsed.data);
+  }
+  return descriptors;
 }
 
 function buildRequestBody(

--- a/packages/providers/src/hetzner-semantic.test.ts
+++ b/packages/providers/src/hetzner-semantic.test.ts
@@ -93,6 +93,7 @@ describe("Hetzner semantic provider adapters", () => {
     );
     expect(serialized).toContain("untrusted quoted data");
     expect(serialized).toContain("Brevity is mandatory");
+    expect(learning.descriptor.provider).toBe("hetzner-inference");
 
     const learningSchema = responseSchemaFromBody(bodies[0]);
     expect(schemaAt(learningSchema, ["result", "changedAreas"])).toMatchObject({
@@ -108,6 +109,41 @@ describe("Hetzner semantic provider adapters", () => {
     expect(
       schemaAt(learningSchema, ["result", "patchIntent", "patchReferences"]),
     ).toMatchObject({ minItems: 1, maxItems: 1 });
+  });
+
+  it("omits Hetzner-only request fields when the same client speaks OpenRouter", async () => {
+    const bodies: unknown[] = [];
+    const fetchImpl = vi.fn(
+      async (_url: string | URL | Request, init?: RequestInit) => {
+        bodies.push(JSON.parse(String(init?.body)) as unknown);
+        return completionResponse({ ok: true });
+      },
+    );
+    const provider = new HetznerLearningMaterialProvider(
+      {
+        provider: "openrouter",
+        baseUrl: "https://openrouter.example.test/api/v1",
+        apiKey: API_KEY,
+        model: "xiaomi/mimo-v2.5",
+      },
+      testDependencies(fetchImpl),
+    );
+
+    expect(provider.descriptor).toEqual({
+      provider: "openrouter",
+      model: "xiaomi/mimo-v2.5",
+    });
+    const result = await provider.generate(
+      learningInput(),
+      context("learning_material"),
+    );
+    expect(result.answeredBy).toEqual(provider.descriptor);
+    expect(bodies[0]).toMatchObject({
+      model: "xiaomi/mimo-v2.5",
+      store: false,
+      stream: true,
+    });
+    expect(bodies[0]).not.toHaveProperty("chat_template_kwargs");
   });
 
   it("extracts the validated result envelope even when the model adds metadata", async () => {
@@ -361,6 +397,7 @@ describe("Hetzner semantic provider adapters", () => {
       output: { malformedSemanticOutput: true },
       tokenUsage: { inputTokens: 20, outputTokens: 6_000 },
       transportAttemptCount: 1,
+      answeredBy: { provider: "hetzner-inference", model: "proof-model" },
     });
   });
 
@@ -431,6 +468,7 @@ describe("Hetzner semantic provider adapters", () => {
         output: { malformedSemanticOutput: true },
         tokenUsage: null,
         transportAttemptCount: 1,
+        answeredBy: { provider: "hetzner-inference", model: "proof-model" },
       },
     );
     await expect(

--- a/packages/providers/src/hetzner-semantic.ts
+++ b/packages/providers/src/hetzner-semantic.ts
@@ -43,8 +43,18 @@ const MAX_SSE_EVENT_BYTES = 256 * 1_024;
 const MAX_SSE_EVENT_COUNT = 20_000;
 const timeoutMarker = Symbol("hetzner-semantic-timeout");
 
+export const CompatibleChatProviderNameSchema = z.enum([
+  "hetzner-inference",
+  "openrouter",
+]);
+
+export type CompatibleChatProviderName = z.infer<
+  typeof CompatibleChatProviderNameSchema
+>;
+
 export const HetznerSemanticProviderConfigV1Schema = z
   .object({
+    provider: CompatibleChatProviderNameSchema.default("hetzner-inference"),
     baseUrl: z.url().refine(isSafeProviderBaseUrl),
     apiKey: z
       .string()
@@ -60,7 +70,7 @@ export const HetznerSemanticProviderConfigV1Schema = z
   })
   .strict();
 
-export type HetznerSemanticProviderConfigV1 = z.infer<
+export type HetznerSemanticProviderConfigV1 = z.input<
   typeof HetznerSemanticProviderConfigV1Schema
 >;
 
@@ -226,6 +236,7 @@ const PROOF_SPECIFICATION = Object.freeze({
 
 class HetznerSemanticHttpClient<TInput> {
   readonly descriptor: SemanticProviderDescriptorV1;
+  private readonly providerName: CompatibleChatProviderName;
   private readonly endpoint: string;
   private readonly apiKey: string;
   private readonly fetchImpl: typeof fetch;
@@ -238,10 +249,11 @@ class HetznerSemanticHttpClient<TInput> {
     dependencies: HetznerSemanticProviderDependencies = {},
   ) {
     const config = parseConfig(rawConfig);
+    this.providerName = config.provider;
     this.endpoint = chatCompletionsEndpoint(config.baseUrl);
     this.apiKey = config.apiKey;
     this.descriptor = SemanticProviderDescriptorV1Schema.parse({
-      provider: "hetzner-inference",
+      provider: config.provider,
       model: config.model,
     });
     this.fetchImpl = dependencies.fetchImpl ?? globalThis.fetch;
@@ -301,6 +313,7 @@ class HetznerSemanticHttpClient<TInput> {
     repairInstruction?: SemanticProviderRepairInstructionV1,
   ): Promise<SemanticProviderRawResponseV1> {
     const requestBody = buildChatRequest(
+      this.providerName,
       this.descriptor.model,
       input,
       this.specification,
@@ -338,6 +351,7 @@ class HetznerSemanticHttpClient<TInput> {
       output,
       tokenUsage: request.usage,
       transportAttemptCount: request.transportAttemptCount,
+      answeredBy: this.descriptor,
     });
   }
 }
@@ -442,6 +456,7 @@ export class HetznerProofQuestionProvider implements ProofQuestionProvider {
 }
 
 function buildChatRequest<TInput>(
+  provider: CompatibleChatProviderName,
   model: string,
   input: TInput,
   specification: SemanticPurposeSpecification,
@@ -452,7 +467,9 @@ function buildChatRequest<TInput>(
     store: false,
     temperature: 0,
     stream: true,
-    chat_template_kwargs: { thinking: false },
+    ...(provider === "hetzner-inference"
+      ? { chat_template_kwargs: { thinking: false } }
+      : {}),
     max_tokens: specification.maximumOutputTokens,
     response_format: {
       type: "json_schema",
@@ -871,7 +888,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function parseConfig(
   rawConfig: HetznerSemanticProviderConfigV1,
-): HetznerSemanticProviderConfigV1 {
+): z.output<typeof HetznerSemanticProviderConfigV1Schema> {
   const result = HetznerSemanticProviderConfigV1Schema.safeParse(rawConfig);
   if (!result.success) {
     throw safeProviderError(

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -7,5 +7,6 @@ export * from "./learning-proof";
 export * from "./openrouter-transcription";
 export * from "./payload-cipher";
 export * from "./semantic-fakes";
+export * from "./transport-fallback";
 
 export const providersPackage = "@slopproof/providers" as const;

--- a/packages/providers/src/learning-proof.ts
+++ b/packages/providers/src/learning-proof.ts
@@ -66,6 +66,7 @@ export const SemanticProviderRawResponseV1Schema = z
     output: z.unknown(),
     tokenUsage: SemanticTokenUsageV1Schema.nullable(),
     transportAttemptCount: z.number().int().min(1).max(3).optional(),
+    answeredBy: SemanticProviderDescriptorV1Schema.optional(),
   })
   .strict();
 

--- a/packages/providers/src/transport-fallback.test.ts
+++ b/packages/providers/src/transport-fallback.test.ts
@@ -1,0 +1,378 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ProviderContextV1 } from "./contracts";
+import { ProviderError } from "./errors";
+import type {
+  InlineMultimodalJudgeProvider,
+  MultimodalJudgeProviderInputV1,
+  MultimodalJudgeProviderResultV1,
+} from "./hetzner-multimodal";
+import type {
+  SemanticProviderCallContextV1,
+  SemanticProviderDescriptorV1,
+  SemanticProviderRawResponseV1,
+  SemanticProviderRepairInstructionV1,
+} from "./learning-proof";
+import {
+  TransportFallbackMultimodalJudgeProvider,
+  TransportFallbackSemanticProvider,
+} from "./transport-fallback";
+
+const CONTEXT: SemanticProviderCallContextV1 = {
+  schemaVersion: "1",
+  callId: "10000000-0000-4000-8000-000000000001",
+  revisionId: "10000000-0000-4000-8000-000000000002",
+  headSha: "a".repeat(40),
+  contextHash: "b".repeat(64),
+  purpose: "learning_material",
+  phase: "initial",
+  deadlineAt: new Date("2026-08-18T12:05:00.000Z"),
+};
+
+const REPAIR: SemanticProviderRepairInstructionV1 = {
+  schemaVersion: "1",
+  invalidOutputHash: "f".repeat(64),
+  validationCode: "schema_invalid",
+  maximumAdditionalAttempts: 1,
+};
+
+describe("TransportFallbackSemanticProvider", () => {
+  it("records the Hetzner hop after a primary transport failure", async () => {
+    const primary = stubSemanticProvider(
+      { provider: "openrouter", model: "xiaomi/mimo-v2.5" },
+      {
+        generate: () => {
+          throw transportUnavailable();
+        },
+        repair: () => {
+          throw new Error("repair must not run");
+        },
+      },
+    );
+    const fallback = stubSemanticProvider(
+      { provider: "hetzner-inference", model: "hetzner-learning" },
+      {
+        generate: () => semanticResponse("fallback-output"),
+        repair: () => {
+          throw new Error("repair must not run");
+        },
+      },
+    );
+    const provider = new TransportFallbackSemanticProvider(primary, fallback);
+
+    const result = await provider.generate({ task: "learning" }, CONTEXT);
+
+    expect(primary.generate).toHaveBeenCalledTimes(1);
+    expect(fallback.generate).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      output: "fallback-output",
+      answeredBy: {
+        provider: "hetzner-inference",
+        model: "hetzner-learning",
+      },
+    });
+    expect(provider.descriptor).toEqual({
+      provider: "openrouter",
+      model: "xiaomi/mimo-v2.5",
+    });
+  });
+
+  it("does not hop to Hetzner after INVALID_OUTPUT or a schema-shaped reject", async () => {
+    const primary = stubSemanticProvider(
+      { provider: "openrouter", model: "xiaomi/mimo-v2.5" },
+      {
+        generate: () => {
+          throw new ProviderError(
+            "INVALID_OUTPUT",
+            "review",
+            "Semantic provider returned invalid bounded output",
+            {
+              telemetry: {
+                lastFailureKind: "invalid_output",
+                httpStatusClass: null,
+                transportAttemptCount: 1,
+              },
+            },
+          );
+        },
+        repair: () => semanticResponse("must-not-run"),
+      },
+    );
+    const fallback = stubSemanticProvider(
+      { provider: "hetzner-inference", model: "hetzner-learning" },
+      {
+        generate: () => semanticResponse("must-not-run"),
+        repair: () => semanticResponse("must-not-run"),
+      },
+    );
+    const provider = new TransportFallbackSemanticProvider(primary, fallback);
+
+    await expect(
+      provider.generate({ task: "learning" }, CONTEXT),
+    ).rejects.toMatchObject({
+      code: "INVALID_OUTPUT",
+    });
+    expect(fallback.generate).not.toHaveBeenCalled();
+    expect(fallback.repair).not.toHaveBeenCalled();
+
+    primary.generate.mockImplementationOnce(() => {
+      throw new ProviderError(
+        "PROVIDER_UNAVAILABLE",
+        "terminal",
+        "Semantic provider rejected the bounded request",
+        {
+          telemetry: {
+            lastFailureKind: "request_rejected",
+            httpStatusClass: "4xx",
+            transportAttemptCount: 1,
+          },
+        },
+      );
+    });
+    await expect(
+      provider.generate({ task: "learning" }, CONTEXT),
+    ).rejects.toMatchObject({
+      code: "PROVIDER_UNAVAILABLE",
+      disposition: "terminal",
+    });
+    expect(fallback.generate).not.toHaveBeenCalled();
+  });
+
+  it("keeps a successful primary answer on OpenRouter", async () => {
+    const primary = stubSemanticProvider(
+      { provider: "openrouter", model: "xiaomi/mimo-v2.5" },
+      {
+        generate: () => semanticResponse("primary-output"),
+        repair: () => semanticResponse("must-not-run"),
+      },
+    );
+    const fallback = stubSemanticProvider(
+      { provider: "hetzner-inference", model: "hetzner-learning" },
+      {
+        generate: () => semanticResponse("must-not-run"),
+        repair: () => semanticResponse("must-not-run"),
+      },
+    );
+
+    const result = await new TransportFallbackSemanticProvider(
+      primary,
+      fallback,
+    ).generate({ task: "learning" }, CONTEXT);
+
+    expect(fallback.generate).not.toHaveBeenCalled();
+    expect(result.answeredBy).toEqual({
+      provider: "openrouter",
+      model: "xiaomi/mimo-v2.5",
+    });
+  });
+
+  it("hops a transport-failed repair and records the answering provider", async () => {
+    const primary = stubSemanticProvider(
+      { provider: "openrouter", model: "xiaomi/mimo-v2.5" },
+      {
+        generate: () => semanticResponse("must-not-run"),
+        repair: () => {
+          throw new ProviderError(
+            "DEADLINE_EXCEEDED",
+            "retryable",
+            "Semantic provider deadline elapsed",
+            {
+              telemetry: {
+                lastFailureKind: "timeout",
+                httpStatusClass: null,
+                transportAttemptCount: 1,
+              },
+            },
+          );
+        },
+      },
+    );
+    const fallback = stubSemanticProvider(
+      { provider: "hetzner-inference", model: "hetzner-learning" },
+      {
+        generate: () => semanticResponse("must-not-run"),
+        repair: () => semanticResponse("repaired-on-hetzner"),
+      },
+    );
+
+    const result = await new TransportFallbackSemanticProvider(
+      primary,
+      fallback,
+    ).repair({ task: "learning" }, REPAIR, { ...CONTEXT, phase: "repair" });
+
+    expect(primary.repair).toHaveBeenCalledTimes(1);
+    expect(fallback.repair).toHaveBeenCalledTimes(1);
+    expect(result.answeredBy).toEqual({
+      provider: "hetzner-inference",
+      model: "hetzner-learning",
+    });
+  });
+});
+
+describe("TransportFallbackMultimodalJudgeProvider", () => {
+  it("records the Hetzner judge after a primary transport failure", async () => {
+    const primary = stubJudgeProvider(
+      {
+        provider: "openrouter",
+        model: "xiaomi/mimo-v2.5",
+        visionModel: "xiaomi/mimo-v2.5",
+      },
+      () => {
+        throw transportUnavailable();
+      },
+    );
+    const fallback = stubJudgeProvider(
+      {
+        provider: "hetzner-inference",
+        model: "hetzner-judge",
+        visionModel: "hetzner-vision",
+      },
+      () =>
+        judgeResult({
+          provider: "hetzner-inference",
+          model: "hetzner-judge",
+        }),
+    );
+    const provider = new TransportFallbackMultimodalJudgeProvider(
+      primary,
+      fallback,
+    );
+
+    const result = await provider.evaluate(
+      {} as MultimodalJudgeProviderInputV1,
+      judgeContext(),
+    );
+
+    expect(primary.evaluate).toHaveBeenCalledTimes(1);
+    expect(fallback.evaluate).toHaveBeenCalledTimes(1);
+    expect(result.metadata.provider).toBe("hetzner-inference");
+    expect(result.metadata.model).toBe("hetzner-judge");
+    expect(provider.descriptor.provider).toBe("openrouter");
+    expect(provider.transportFallbackDescriptor.provider).toBe(
+      "hetzner-inference",
+    );
+  });
+
+  it("does not hop the judge after INVALID_OUTPUT", async () => {
+    const primary = stubJudgeProvider(
+      {
+        provider: "openrouter",
+        model: "xiaomi/mimo-v2.5",
+        visionModel: "xiaomi/mimo-v2.5",
+      },
+      () => {
+        throw new ProviderError(
+          "INVALID_OUTPUT",
+          "review",
+          "Multimodal provider output is invalid",
+        );
+      },
+    );
+    const fallback = stubJudgeProvider(
+      {
+        provider: "hetzner-inference",
+        model: "hetzner-judge",
+        visionModel: "hetzner-vision",
+      },
+      () => {
+        throw new Error("fallback must not run");
+      },
+    );
+
+    await expect(
+      new TransportFallbackMultimodalJudgeProvider(primary, fallback).evaluate(
+        {} as MultimodalJudgeProviderInputV1,
+        judgeContext(),
+      ),
+    ).rejects.toMatchObject({ code: "INVALID_OUTPUT" });
+    expect(fallback.evaluate).not.toHaveBeenCalled();
+  });
+});
+
+function transportUnavailable(): ProviderError {
+  return new ProviderError(
+    "PROVIDER_UNAVAILABLE",
+    "retryable",
+    "Semantic provider is temporarily unavailable",
+    {
+      telemetry: {
+        lastFailureKind: "upstream_unavailable",
+        httpStatusClass: "5xx",
+        transportAttemptCount: 3,
+      },
+    },
+  );
+}
+
+function semanticResponse(output: unknown): SemanticProviderRawResponseV1 {
+  return {
+    output,
+    tokenUsage: { inputTokens: 4, outputTokens: 2 },
+    transportAttemptCount: 1,
+  };
+}
+
+function stubSemanticProvider(
+  descriptor: SemanticProviderDescriptorV1,
+  behavior: {
+    generate(): SemanticProviderRawResponseV1;
+    repair(): SemanticProviderRawResponseV1;
+  },
+) {
+  return {
+    descriptor,
+    generate: vi.fn(async () => behavior.generate()),
+    repair: vi.fn(async () => behavior.repair()),
+  };
+}
+
+function stubJudgeProvider(
+  descriptor: InlineMultimodalJudgeProvider["descriptor"],
+  evaluate: () => MultimodalJudgeProviderResultV1,
+): InlineMultimodalJudgeProvider & {
+  evaluate: ReturnType<typeof vi.fn>;
+} {
+  return {
+    descriptor,
+    evaluate: vi.fn(async () => evaluate()),
+  };
+}
+
+function judgeResult(metadata: {
+  provider: string;
+  model: string;
+}): MultimodalJudgeProviderResultV1 {
+  return {
+    candidate: {
+      schemaVersion: "1",
+      candidateVersion: "multimodal-judge-candidate-v1",
+      recommendation: "review_required",
+      questionEvaluations: [],
+      privateReason: "automated_evaluation_unavailable",
+      warnings: [],
+    },
+    metadata: {
+      schemaVersion: "1",
+      provider: metadata.provider,
+      model: metadata.model,
+      promptVersion: "proof-judge-system-v2",
+      outputSchemaVersion: "multimodal-judge-candidate-v1",
+      inputHash: "a".repeat(64),
+      outputHash: "b".repeat(64),
+      tokenUsage: null,
+      latencyMs: 10,
+      invocationCount: 1,
+      outcome: "generated",
+      degraded: false,
+      completedAt: new Date("2026-08-18T12:00:00.000Z"),
+    },
+  } as MultimodalJudgeProviderResultV1;
+}
+
+function judgeContext(): ProviderContextV1 {
+  return {
+    schemaVersion: "1",
+    requestId: "10000000-0000-4000-8000-000000000010",
+    attemptId: "10000000-0000-4000-8000-000000000011",
+    deadlineAt: new Date("2026-08-18T12:05:00.000Z"),
+  };
+}

--- a/packages/providers/src/transport-fallback.ts
+++ b/packages/providers/src/transport-fallback.ts
@@ -1,0 +1,118 @@
+import { isTransportFailure } from "./errors";
+import {
+  SemanticProviderDescriptorV1Schema,
+  SemanticProviderRawResponseV1Schema,
+  type SemanticProviderCallContextV1,
+  type SemanticProviderDescriptorV1,
+  type SemanticProviderRawResponseV1,
+  type SemanticProviderRepairInstructionV1,
+} from "./learning-proof";
+import type {
+  InlineMultimodalJudgeDescriptorV1,
+  InlineMultimodalJudgeProvider,
+  MultimodalJudgeProviderInputV1,
+  MultimodalJudgeProviderResultV1,
+} from "./hetzner-multimodal";
+import type { ProviderContextV1 } from "./contracts";
+
+type RepairableSemanticProvider<TInput> = {
+  readonly descriptor: SemanticProviderDescriptorV1;
+  generate(
+    input: TInput,
+    context: SemanticProviderCallContextV1,
+  ): Promise<SemanticProviderRawResponseV1>;
+  repair(
+    input: TInput,
+    instruction: SemanticProviderRepairInstructionV1,
+    context: SemanticProviderCallContextV1,
+  ): Promise<SemanticProviderRawResponseV1>;
+};
+
+export class TransportFallbackSemanticProvider<
+  TInput,
+> implements RepairableSemanticProvider<TInput> {
+  readonly descriptor: SemanticProviderDescriptorV1;
+
+  constructor(
+    private readonly primary: RepairableSemanticProvider<TInput>,
+    private readonly fallback: RepairableSemanticProvider<TInput>,
+  ) {
+    this.descriptor = primary.descriptor;
+  }
+
+  generate(
+    input: TInput,
+    context: SemanticProviderCallContextV1,
+  ): Promise<SemanticProviderRawResponseV1> {
+    return this.invoke(
+      () => this.primary.generate(input, context),
+      () => this.fallback.generate(input, context),
+      this.primary.descriptor,
+      this.fallback.descriptor,
+    );
+  }
+
+  repair(
+    input: TInput,
+    instruction: SemanticProviderRepairInstructionV1,
+    context: SemanticProviderCallContextV1,
+  ): Promise<SemanticProviderRawResponseV1> {
+    return this.invoke(
+      () => this.primary.repair(input, instruction, context),
+      () => this.fallback.repair(input, instruction, context),
+      this.primary.descriptor,
+      this.fallback.descriptor,
+    );
+  }
+
+  private async invoke(
+    primaryCall: () => Promise<SemanticProviderRawResponseV1>,
+    fallbackCall: () => Promise<SemanticProviderRawResponseV1>,
+    primaryDescriptor: SemanticProviderDescriptorV1,
+    fallbackDescriptor: SemanticProviderDescriptorV1,
+  ): Promise<SemanticProviderRawResponseV1> {
+    try {
+      return attachAnsweredBy(await primaryCall(), primaryDescriptor);
+    } catch (error) {
+      if (!isTransportFailure(error)) throw error;
+      return attachAnsweredBy(await fallbackCall(), fallbackDescriptor);
+    }
+  }
+}
+
+export class TransportFallbackMultimodalJudgeProvider implements InlineMultimodalJudgeProvider {
+  readonly descriptor: InlineMultimodalJudgeDescriptorV1;
+  readonly transportFallbackDescriptor: InlineMultimodalJudgeDescriptorV1;
+
+  constructor(
+    private readonly primary: InlineMultimodalJudgeProvider,
+    private readonly fallback: InlineMultimodalJudgeProvider,
+  ) {
+    this.descriptor = primary.descriptor;
+    this.transportFallbackDescriptor = fallback.descriptor;
+  }
+
+  async evaluate(
+    input: MultimodalJudgeProviderInputV1,
+    context: ProviderContextV1,
+  ): Promise<MultimodalJudgeProviderResultV1> {
+    try {
+      return await this.primary.evaluate(input, context);
+    } catch (error) {
+      if (!isTransportFailure(error)) throw error;
+      return await this.fallback.evaluate(input, context);
+    }
+  }
+}
+
+function attachAnsweredBy(
+  response: SemanticProviderRawResponseV1,
+  descriptor: SemanticProviderDescriptorV1,
+): SemanticProviderRawResponseV1 {
+  return SemanticProviderRawResponseV1Schema.parse({
+    ...response,
+    answeredBy: SemanticProviderDescriptorV1Schema.parse(
+      response.answeredBy ?? descriptor,
+    ),
+  });
+}

--- a/scripts/lib/live-smoke.mjs
+++ b/scripts/lib/live-smoke.mjs
@@ -1,5 +1,18 @@
 const DEFAULT_MAX_RESPONSE_BYTES = 128 * 1024;
+const DEFAULT_MAX_SSE_EVENTS = 256;
+const DEFAULT_MAX_SSE_EVENT_BYTES = 16 * 1024;
+const MAX_SSE_EVENTS = 20_000;
+const MAX_SSE_EVENT_BYTES = 256 * 1_024;
+const MAX_MODEL_CONTENT_BYTES = 64 * 1_024;
 const MAX_ATTEMPTS = 3;
+const OPENROUTER_MIMO_CAPABILITY_SCHEMA = Object.freeze({
+  type: "object",
+  properties: Object.freeze({
+    ok: Object.freeze({ type: "boolean", const: true }),
+  }),
+  required: Object.freeze(["ok"]),
+  additionalProperties: false,
+});
 
 export class LiveSmokeError extends Error {
   constructor(code, fields = []) {
@@ -115,6 +128,199 @@ async function readBoundedJsonResponse(
   }
 }
 
+export async function readBoundedSseChatContent(
+  response,
+  {
+    maxBytes = DEFAULT_MAX_RESPONSE_BYTES,
+    maxEvents = DEFAULT_MAX_SSE_EVENTS,
+    maxEventBytes = DEFAULT_MAX_SSE_EVENT_BYTES,
+  } = {},
+) {
+  if (
+    !Number.isInteger(maxBytes) ||
+    maxBytes < 1 ||
+    maxBytes > 1024 * 1024 ||
+    !Number.isInteger(maxEvents) ||
+    maxEvents < 1 ||
+    maxEvents > MAX_SSE_EVENTS ||
+    !Number.isInteger(maxEventBytes) ||
+    maxEventBytes < 1 ||
+    maxEventBytes > MAX_SSE_EVENT_BYTES
+  ) {
+    throw new LiveSmokeError("invalid_request");
+  }
+
+  const contentType = response.headers
+    .get("content-type")
+    ?.split(";", 1)[0]
+    ?.trim()
+    .toLowerCase();
+  if (contentType !== "text/event-stream") {
+    try {
+      await response.body?.cancel();
+    } catch {
+      // Wrong content-type is already a protocol failure.
+    }
+    throw new LiveSmokeError("malformed_response");
+  }
+
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    try {
+      await response.body?.cancel();
+    } catch {
+      // The response is already being rejected; cancellation is best effort.
+    }
+    throw new LiveSmokeError("response_too_large");
+  }
+  if (!response.body) {
+    throw new LiveSmokeError("malformed_response");
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let bytesRead = 0;
+  let pending = "";
+  let eventData = [];
+  let eventBytes = 0;
+  let eventCount = 0;
+  let doneSeen = false;
+  let content = "";
+  let contentBytes = 0;
+  let finishReason = null;
+
+  const commitEvent = () => {
+    if (eventData.length === 0) return;
+    const data = eventData.join("\n");
+    eventData = [];
+    eventBytes = 0;
+    if (data === "[DONE]") {
+      doneSeen = true;
+      return;
+    }
+    if (doneSeen || (eventCount += 1) > maxEvents) {
+      throw new LiveSmokeError("malformed_response");
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(data.replace(/^\uFEFF/u, ""));
+    } catch {
+      throw new LiveSmokeError("malformed_response");
+    }
+    const chunk = parseSseChatChunk(parsed);
+    if (chunk.content !== undefined) {
+      const deltaBytes = Buffer.byteLength(chunk.content, "utf8");
+      if (contentBytes + deltaBytes > MAX_MODEL_CONTENT_BYTES) {
+        throw new LiveSmokeError("response_too_large");
+      }
+      content += chunk.content;
+      contentBytes += deltaBytes;
+    }
+    if (chunk.finishReason !== undefined) {
+      if (finishReason !== null && finishReason !== chunk.finishReason) {
+        throw new LiveSmokeError("malformed_response");
+      }
+      finishReason = chunk.finishReason;
+    }
+  };
+
+  const acceptLine = (rawLine) => {
+    const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+    if (line.length === 0) {
+      commitEvent();
+      return;
+    }
+    if (line.startsWith(":")) return;
+    const separator = line.indexOf(":");
+    const field = separator === -1 ? line : line.slice(0, separator);
+    if (field !== "data") return;
+    let value = separator === -1 ? "" : line.slice(separator + 1);
+    if (value.startsWith(" ")) value = value.slice(1);
+    const valueBytes = Buffer.byteLength(value, "utf8");
+    if (eventBytes + valueBytes > maxEventBytes) {
+      throw new LiveSmokeError("response_too_large");
+    }
+    eventData.push(value);
+    eventBytes += valueBytes;
+  };
+
+  const acceptText = (value) => {
+    pending += value;
+    let newline = pending.indexOf("\n");
+    while (newline !== -1) {
+      acceptLine(pending.slice(0, newline));
+      pending = pending.slice(newline + 1);
+      newline = pending.indexOf("\n");
+    }
+    if (Buffer.byteLength(pending, "utf8") > maxEventBytes) {
+      throw new LiveSmokeError("response_too_large");
+    }
+  };
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      bytesRead += value.byteLength;
+      if (bytesRead > maxBytes) {
+        await reader.cancel();
+        throw new LiveSmokeError("response_too_large");
+      }
+      acceptText(decoder.decode(value, { stream: true }));
+    }
+    acceptText(decoder.decode());
+    if (pending.length > 0) {
+      acceptLine(pending);
+      pending = "";
+    }
+    commitEvent();
+    if (!doneSeen || finishReason !== "stop" || content.length === 0) {
+      throw new LiveSmokeError("malformed_response");
+    }
+    return content;
+  } catch (error) {
+    if (error instanceof LiveSmokeError) throw error;
+    throw new LiveSmokeError("response_stream_failed");
+  }
+}
+
+function parseSseChatChunk(parsed) {
+  if (
+    !isRecord(parsed) ||
+    !Array.isArray(parsed.choices) ||
+    parsed.choices.length > 8
+  ) {
+    throw new LiveSmokeError("malformed_response");
+  }
+  if (parsed.choices.length === 0) {
+    return {};
+  }
+  const choice = parsed.choices[0];
+  if (!isRecord(choice) || !isRecord(choice.delta)) {
+    throw new LiveSmokeError("malformed_response");
+  }
+  const content = choice.delta.content;
+  if (
+    content !== undefined &&
+    content !== null &&
+    typeof content !== "string"
+  ) {
+    throw new LiveSmokeError("malformed_response");
+  }
+  const finishReason = choice.finish_reason;
+  if (
+    finishReason !== undefined &&
+    finishReason !== null &&
+    typeof finishReason !== "string"
+  ) {
+    throw new LiveSmokeError("malformed_response");
+  }
+  return {
+    ...(typeof content === "string" ? { content } : {}),
+    ...(typeof finishReason === "string" ? { finishReason } : {}),
+  };
+}
+
 function backoffMilliseconds(attempt, random) {
   const base = Math.min(120 * 2 ** (attempt - 1), 600);
   return Math.round(base * (0.75 + random() * 0.5));
@@ -156,9 +362,80 @@ function validateRetryOptions({
   }
 }
 
-export async function requestJsonWithRetry({
+export async function requestJsonWithRetry(options) {
+  return runRequestWithRetry({
+    ...options,
+    readOkResponse: (response, maxResponseBytes) =>
+      readBoundedJsonResponse(response, maxResponseBytes),
+  });
+}
+
+export async function requestSseChatWithRetry({
+  maxSseEvents = DEFAULT_MAX_SSE_EVENTS,
+  maxSseEventBytes = DEFAULT_MAX_SSE_EVENT_BYTES,
+  ...options
+} = {}) {
+  if (
+    !Number.isInteger(maxSseEvents) ||
+    maxSseEvents < 1 ||
+    maxSseEvents > MAX_SSE_EVENTS ||
+    !Number.isInteger(maxSseEventBytes) ||
+    maxSseEventBytes < 1 ||
+    maxSseEventBytes > MAX_SSE_EVENT_BYTES
+  ) {
+    throw new LiveSmokeError("invalid_request");
+  }
+  return runRequestWithRetry({
+    ...options,
+    readOkResponse: (response, maxResponseBytes) =>
+      readBoundedSseChatContent(response, {
+        maxBytes: maxResponseBytes,
+        maxEvents: maxSseEvents,
+        maxEventBytes: maxSseEventBytes,
+      }),
+  });
+}
+
+export function buildOpenRouterMimoCapabilityBody(model) {
+  if (
+    typeof model !== "string" ||
+    model.trim().length === 0 ||
+    /[\0\r\n]/u.test(model)
+  ) {
+    throw new LiveSmokeError("invalid_environment", ["LEARNING_MODEL"]);
+  }
+  return {
+    model,
+    store: false,
+    temperature: 0,
+    stream: true,
+    max_tokens: 64,
+    response_format: {
+      type: "json_schema",
+      json_schema: {
+        name: "slopproof_openrouter_mimo_capability",
+        strict: true,
+        schema: OPENROUTER_MIMO_CAPABILITY_SCHEMA,
+      },
+    },
+    messages: [
+      {
+        role: "system",
+        content:
+          "This is a fixed capability check. Do not call tools. Return only the requested JSON object.",
+      },
+      {
+        role: "user",
+        content: 'Return the JSON object {"ok":true}. Do not use Markdown.',
+      },
+    ],
+  };
+}
+
+async function runRequestWithRetry({
   url,
   makeInit,
+  readOkResponse,
   fetchImpl = globalThis.fetch,
   maxAttempts = MAX_ATTEMPTS,
   deadlineMs = 25_000,
@@ -178,6 +455,7 @@ export async function requestJsonWithRetry({
   if (
     typeof fetchImpl !== "function" ||
     typeof makeInit !== "function" ||
+    typeof readOkResponse !== "function" ||
     typeof now !== "function" ||
     typeof random !== "function" ||
     typeof sleep !== "function"
@@ -219,7 +497,7 @@ export async function requestJsonWithRetry({
       if (response) {
         if (response.ok) {
           try {
-            return await readBoundedJsonResponse(response, maxResponseBytes);
+            return await readOkResponse(response, maxResponseBytes);
           } catch (error) {
             if (controller.signal.aborted) {
               failureCode = "provider_timeout";

--- a/scripts/lib/live-smoke.test.mjs
+++ b/scripts/lib/live-smoke.test.mjs
@@ -4,12 +4,15 @@ import {
   assertExactObject,
   assertTranscriptionPayload,
   buildApiUrl,
+  buildOpenRouterMimoCapabilityBody,
   createTinyWavFixture,
   extractJsonObject,
   getChatMessageContent,
   isLiveSmokeEnabled,
   LiveSmokeError,
+  readBoundedSseChatContent,
   requestJsonWithRetry,
+  requestSseChatWithRetry,
   requireSmokeEnvironment,
   runGuardedLiveSmoke,
 } from "./live-smoke.mjs";
@@ -42,6 +45,34 @@ test("environment validation returns canonical values without leaking them", () 
       assert.equal(String(error).includes(secret), false);
       return true;
     },
+  );
+
+  const openrouter = requireSmokeEnvironment(
+    {
+      GENERATION_PROVIDER: "openrouter",
+      GENERATION_BASE_URL: "https://openrouter.example/api/v1",
+      GENERATION_API_KEY: secret,
+      LEARNING_MODEL: "configured-generation-model",
+    },
+    {
+      GENERATION_PROVIDER: "openrouter",
+      GENERATION_BASE_URL: undefined,
+      GENERATION_API_KEY: undefined,
+      LEARNING_MODEL: undefined,
+    },
+  );
+  assert.equal(openrouter.LEARNING_MODEL, "configured-generation-model");
+  assert.throws(
+    () =>
+      requireSmokeEnvironment(
+        { GENERATION_PROVIDER: "hetzner", GENERATION_API_KEY: secret },
+        { GENERATION_PROVIDER: "openrouter", GENERATION_API_KEY: undefined },
+      ),
+    (error) =>
+      error instanceof LiveSmokeError &&
+      error.code === "invalid_environment" &&
+      error.fields.join() === "GENERATION_PROVIDER" &&
+      String(error).includes(secret) === false,
   );
 });
 
@@ -201,6 +232,208 @@ test("request helper rejects an oversized response before parsing it", async () 
     (error) =>
       error instanceof LiveSmokeError && error.code === "response_too_large",
   );
+});
+
+test("OpenRouter MiMo capability body matches the streamed json_schema wire", () => {
+  const body = buildOpenRouterMimoCapabilityBody("configured-generation-model");
+  assert.deepEqual(body, {
+    model: "configured-generation-model",
+    store: false,
+    temperature: 0,
+    stream: true,
+    max_tokens: 64,
+    response_format: {
+      type: "json_schema",
+      json_schema: {
+        name: "slopproof_openrouter_mimo_capability",
+        strict: true,
+        schema: {
+          type: "object",
+          properties: { ok: { type: "boolean", const: true } },
+          required: ["ok"],
+          additionalProperties: false,
+        },
+      },
+    },
+    messages: [
+      {
+        role: "system",
+        content:
+          "This is a fixed capability check. Do not call tools. Return only the requested JSON object.",
+      },
+      {
+        role: "user",
+        content: 'Return the JSON object {"ok":true}. Do not use Markdown.',
+      },
+    ],
+  });
+  assert.equal(Object.hasOwn(body, "chat_template_kwargs"), false);
+  assert.equal(Object.hasOwn(body, "tools"), false);
+  assert.throws(
+    () => buildOpenRouterMimoCapabilityBody("model\nname"),
+    (error) =>
+      error instanceof LiveSmokeError &&
+      error.code === "invalid_environment" &&
+      error.fields.join() === "LEARNING_MODEL",
+  );
+});
+
+function sseChatResponse(events, headers = {}) {
+  return new Response(
+    `${events
+      .map((event) =>
+        typeof event === "string"
+          ? `data: ${event}\n\n`
+          : `data: ${JSON.stringify(event)}\n\n`,
+      )
+      .join("")}`,
+    {
+      status: 200,
+      headers: {
+        "content-type": "text/event-stream; charset=utf-8",
+        ...headers,
+      },
+    },
+  );
+}
+
+function mimoOkEvents() {
+  return [
+    { choices: [{ delta: { content: '{"ok":' }, finish_reason: null }] },
+    { choices: [{ delta: { content: "true}" }, finish_reason: "stop" }] },
+    "[DONE]",
+  ];
+}
+
+test("SSE reader reconstructs streamed chat JSON and rejects non-event-stream", async () => {
+  assert.equal(
+    await readBoundedSseChatContent(sseChatResponse(mimoOkEvents())),
+    '{"ok":true}',
+  );
+
+  await assert.rejects(
+    readBoundedSseChatContent(
+      new Response('{"ok":true}', {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    ),
+    (error) =>
+      error instanceof LiveSmokeError && error.code === "malformed_response",
+  );
+  await assert.rejects(
+    readBoundedSseChatContent(sseChatResponse(mimoOkEvents().slice(0, 2))),
+    (error) =>
+      error instanceof LiveSmokeError && error.code === "malformed_response",
+  );
+  await assert.rejects(
+    readBoundedSseChatContent(
+      sseChatResponse([
+        {
+          choices: [
+            { delta: { content: '{"ok":true}' }, finish_reason: "length" },
+          ],
+        },
+        "[DONE]",
+      ]),
+    ),
+    (error) =>
+      error instanceof LiveSmokeError && error.code === "malformed_response",
+  );
+  await assert.rejects(
+    readBoundedSseChatContent(sseChatResponse(["not-json", "[DONE]"])),
+    (error) =>
+      error instanceof LiveSmokeError && error.code === "malformed_response",
+  );
+});
+
+test("SSE reader enforces byte and event caps", async () => {
+  await assert.rejects(
+    readBoundedSseChatContent(sseChatResponse(mimoOkEvents()), {
+      maxEvents: 1,
+    }),
+    (error) =>
+      error instanceof LiveSmokeError && error.code === "malformed_response",
+  );
+  await assert.rejects(
+    readBoundedSseChatContent(
+      sseChatResponse(mimoOkEvents(), { "content-length": "999" }),
+      { maxBytes: 16 },
+    ),
+    (error) =>
+      error instanceof LiveSmokeError && error.code === "response_too_large",
+  );
+});
+
+test("SSE request helper retries only retryable statuses and rebuilds the request", async () => {
+  const statuses = [429, 503, 200];
+  const delays = [];
+  let initCount = 0;
+  let fetchCount = 0;
+
+  const result = await requestSseChatWithRetry({
+    url: "https://provider.example/api/v1/chat/completions",
+    makeInit: () => {
+      initCount += 1;
+      return { method: "POST" };
+    },
+    fetchImpl: async () => {
+      const status = statuses[fetchCount];
+      fetchCount += 1;
+      if (status !== 200) {
+        return new Response("discarded", { status });
+      }
+      return sseChatResponse(mimoOkEvents());
+    },
+    random: () => 0,
+    sleep: async (milliseconds) => delays.push(milliseconds),
+  });
+
+  assert.equal(result, '{"ok":true}');
+  assert.equal(fetchCount, 3);
+  assert.equal(initCount, 3);
+  assert.deepEqual(delays, [90, 180]);
+});
+
+test("SSE request helper does not retry non-429 client failures or JSON content", async () => {
+  let rejectedCount = 0;
+  await assert.rejects(
+    requestSseChatWithRetry({
+      url: "https://provider.example/api/v1/chat/completions",
+      makeInit: () => ({ method: "POST" }),
+      fetchImpl: async () => {
+        rejectedCount += 1;
+        return new Response("not logged", { status: 400 });
+      },
+      sleep: async () => assert.fail("must not sleep for a 400 response"),
+    }),
+    (error) =>
+      error instanceof LiveSmokeError && error.code === "provider_rejected",
+  );
+  assert.equal(rejectedCount, 1);
+
+  let jsonCount = 0;
+  await assert.rejects(
+    requestSseChatWithRetry({
+      url: "https://provider.example/api/v1/chat/completions",
+      makeInit: () => ({ method: "POST" }),
+      fetchImpl: async () => {
+        jsonCount += 1;
+        return new Response(
+          '{"choices":[{"message":{"content":"{\\"ok\\":true}"}}]}',
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        );
+      },
+      maxAttempts: 2,
+      sleep: async () => assert.fail("must not hop or retry a JSON response"),
+    }),
+    (error) =>
+      error instanceof LiveSmokeError && error.code === "malformed_response",
+  );
+  assert.equal(jsonCount, 1);
 });
 
 test("tiny WAV fixture is one second of bounded PCM16 mono audio", () => {

--- a/scripts/lib/production-environment.test.ts
+++ b/scripts/lib/production-environment.test.ts
@@ -72,6 +72,57 @@ const sourceEnvironment = {
 } as const;
 
 describe("production environment compiler", () => {
+  it("compiles OpenRouter-primary generation and judge with Hetzner transport fallback", () => {
+    const compiled = compileProductionEnvironment({
+      ...sourceEnvironment,
+      GENERATION_PROVIDER: "openrouter",
+      GENERATION_BASE_URL: "https://openrouter.ai/api/v1",
+      LEARNING_MODEL: "xiaomi/mimo-v2.5",
+      PRACTICE_MODEL: "xiaomi/mimo-v2.5",
+      PROOF_QUESTION_MODEL: "xiaomi/mimo-v2.5",
+      GENERATION_FALLBACK_BASE_URL: "https://inference.example/api/v1",
+      GENERATION_FALLBACK_API_KEY: "h".repeat(48),
+      LEARNING_FALLBACK_MODEL: "hetzner-learning",
+      PRACTICE_FALLBACK_MODEL: "hetzner-practice",
+      PROOF_QUESTION_FALLBACK_MODEL: "hetzner-proof",
+      MULTIMODAL_JUDGE_PROVIDER: "openrouter",
+      JUDGE_BASE_URL: "https://openrouter.ai/api/v1",
+      JUDGE_MODEL: "xiaomi/mimo-v2.5",
+      JUDGE_FALLBACK_MODEL: "xiaomi/mimo-v2.5",
+      JUDGE_TRANSPORT_FALLBACK_BASE_URL: "https://inference.example/api/v1",
+      JUDGE_TRANSPORT_FALLBACK_API_KEY: "k".repeat(48),
+      JUDGE_TRANSPORT_FALLBACK_MODEL: "hetzner-judge",
+      JUDGE_TRANSPORT_FALLBACK_VISION_MODEL: "hetzner-vision",
+    });
+
+    expect(compiled.GENERATION_PROVIDER).toBe("openrouter");
+    expect(compiled.MULTIMODAL_JUDGE_PROVIDER).toBe("openrouter");
+    expect(compiled.LEARNING_MODEL).toBe("xiaomi/mimo-v2.5");
+    expect(compiled.GENERATION_FALLBACK_BASE_URL).toBe(
+      "https://inference.example/api/v1",
+    );
+    expect(compiled.JUDGE_TRANSPORT_FALLBACK_MODEL).toBe("hetzner-judge");
+    expect(
+      partitionProductionEnvironment(compiled).worker
+        .GENERATION_FALLBACK_API_KEY,
+    ).toBe("h".repeat(48));
+    expect(
+      partitionProductionEnvironment(
+        compileProductionEnvironment(sourceEnvironment),
+      ).worker,
+    ).not.toHaveProperty("GENERATION_FALLBACK_API_KEY");
+  });
+
+  it("rejects OpenRouter production generation without a Hetzner fallback URL", () => {
+    expect(() =>
+      compileProductionEnvironment({
+        ...sourceEnvironment,
+        GENERATION_PROVIDER: "openrouter",
+        GENERATION_BASE_URL: "https://openrouter.ai/api/v1",
+      }),
+    ).toThrowError(ProductionEnvironmentError);
+  });
+
   it("maps canonical S3 runtime names without provider-specific aliases", () => {
     const compiled = compileProductionEnvironment(sourceEnvironment);
 

--- a/scripts/lib/production-environment.ts
+++ b/scripts/lib/production-environment.ts
@@ -61,6 +61,16 @@ function requiredExact(
   return value;
 }
 
+function requiredOneOf(
+  environment: Environment,
+  name: string,
+  expected: readonly string[],
+): string {
+  const value = required(environment, name);
+  if (!expected.includes(value)) throw new ProductionEnvironmentError([name]);
+  return value;
+}
+
 function containerPath(
   environment: Environment,
   name: string,
@@ -79,8 +89,15 @@ export function compileProductionEnvironment(
   requiredExact(environment, "NODE_ENV", "production");
   requiredExact(environment, "DEMO_MODE", "false");
   requiredExact(environment, "GITHUB_ADAPTER", "octokit");
-  requiredExact(environment, "GENERATION_PROVIDER", "hetzner");
-  requiredExact(environment, "MULTIMODAL_JUDGE_PROVIDER", "hetzner");
+  const generationProvider = requiredOneOf(environment, "GENERATION_PROVIDER", [
+    "hetzner",
+    "openrouter",
+  ]);
+  const judgeProvider = requiredOneOf(
+    environment,
+    "MULTIMODAL_JUDGE_PROVIDER",
+    ["hetzner", "openrouter"],
+  );
   requiredExact(environment, "TRANSCRIPTION_PROVIDER", "openrouter");
   requiredExact(environment, "EVIDENCE_STORAGE_PROVIDER", "s3");
 
@@ -126,18 +143,62 @@ export function compileProductionEnvironment(
     OAUTH_TRUSTED_PROXY_SECRET:
       deriveOAuthTrustedProxySecret(workerInternalSecret),
 
-    GENERATION_PROVIDER: "hetzner",
+    GENERATION_PROVIDER: generationProvider,
     GENERATION_BASE_URL: required(environment, "GENERATION_BASE_URL"),
     GENERATION_API_KEY: required(environment, "GENERATION_API_KEY"),
     LEARNING_MODEL: required(environment, "LEARNING_MODEL"),
     PRACTICE_MODEL: required(environment, "PRACTICE_MODEL"),
     PROOF_QUESTION_MODEL: required(environment, "PROOF_QUESTION_MODEL"),
+    ...(generationProvider === "openrouter"
+      ? {
+          GENERATION_FALLBACK_BASE_URL: required(
+            environment,
+            "GENERATION_FALLBACK_BASE_URL",
+          ),
+          GENERATION_FALLBACK_API_KEY: required(
+            environment,
+            "GENERATION_FALLBACK_API_KEY",
+          ),
+          LEARNING_FALLBACK_MODEL: required(
+            environment,
+            "LEARNING_FALLBACK_MODEL",
+          ),
+          PRACTICE_FALLBACK_MODEL: required(
+            environment,
+            "PRACTICE_FALLBACK_MODEL",
+          ),
+          PROOF_QUESTION_FALLBACK_MODEL: required(
+            environment,
+            "PROOF_QUESTION_FALLBACK_MODEL",
+          ),
+        }
+      : {}),
 
-    MULTIMODAL_JUDGE_PROVIDER: "hetzner",
+    MULTIMODAL_JUDGE_PROVIDER: judgeProvider,
     JUDGE_BASE_URL: required(environment, "JUDGE_BASE_URL"),
     JUDGE_API_KEY: required(environment, "JUDGE_API_KEY"),
     JUDGE_MODEL: required(environment, "JUDGE_MODEL"),
     JUDGE_FALLBACK_MODEL: required(environment, "JUDGE_FALLBACK_MODEL"),
+    ...(judgeProvider === "openrouter"
+      ? {
+          JUDGE_TRANSPORT_FALLBACK_BASE_URL: required(
+            environment,
+            "JUDGE_TRANSPORT_FALLBACK_BASE_URL",
+          ),
+          JUDGE_TRANSPORT_FALLBACK_API_KEY: required(
+            environment,
+            "JUDGE_TRANSPORT_FALLBACK_API_KEY",
+          ),
+          JUDGE_TRANSPORT_FALLBACK_MODEL: required(
+            environment,
+            "JUDGE_TRANSPORT_FALLBACK_MODEL",
+          ),
+          JUDGE_TRANSPORT_FALLBACK_VISION_MODEL: required(
+            environment,
+            "JUDGE_TRANSPORT_FALLBACK_VISION_MODEL",
+          ),
+        }
+      : {}),
 
     TRANSCRIPTION_PROVIDER: "openrouter",
     TRANSCRIPTION_BASE_URL: required(environment, "TRANSCRIPTION_BASE_URL"),
@@ -299,11 +360,20 @@ const workerEnvironmentNames = [
   "LEARNING_MODEL",
   "PRACTICE_MODEL",
   "PROOF_QUESTION_MODEL",
+  "GENERATION_FALLBACK_BASE_URL",
+  "GENERATION_FALLBACK_API_KEY",
+  "LEARNING_FALLBACK_MODEL",
+  "PRACTICE_FALLBACK_MODEL",
+  "PROOF_QUESTION_FALLBACK_MODEL",
   "MULTIMODAL_JUDGE_PROVIDER",
   "JUDGE_BASE_URL",
   "JUDGE_API_KEY",
   "JUDGE_MODEL",
   "JUDGE_FALLBACK_MODEL",
+  "JUDGE_TRANSPORT_FALLBACK_BASE_URL",
+  "JUDGE_TRANSPORT_FALLBACK_API_KEY",
+  "JUDGE_TRANSPORT_FALLBACK_MODEL",
+  "JUDGE_TRANSPORT_FALLBACK_VISION_MODEL",
   "TRANSCRIPTION_PROVIDER",
   "TRANSCRIPTION_BASE_URL",
   "TRANSCRIPTION_API_KEY",
@@ -348,7 +418,11 @@ function selectEnvironment(
   names: readonly string[],
 ): Readonly<Record<string, string>> {
   return Object.freeze(
-    Object.fromEntries(names.map((name) => [name, environment[name] ?? ""])),
+    Object.fromEntries(
+      names
+        .filter((name) => environment[name] !== undefined)
+        .map((name) => [name, environment[name] ?? ""]),
+    ),
   );
 }
 

--- a/scripts/live-smoke-openrouter-mimo.mjs
+++ b/scripts/live-smoke-openrouter-mimo.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+import {
+  assertExactObject,
+  buildApiUrl,
+  buildOpenRouterMimoCapabilityBody,
+  LiveSmokeError,
+  requestSseChatWithRetry,
+  requireSmokeEnvironment,
+  runGuardedLiveSmoke,
+} from "./lib/live-smoke.mjs";
+
+const EXPECTED_JSON = Object.freeze({ ok: true });
+
+async function main() {
+  const configuration = requireSmokeEnvironment(process.env, {
+    GENERATION_PROVIDER: "openrouter",
+    GENERATION_BASE_URL: undefined,
+    GENERATION_API_KEY: undefined,
+    LEARNING_MODEL: undefined,
+  });
+  const endpoint = buildApiUrl(
+    configuration.GENERATION_BASE_URL,
+    "/chat/completions",
+  );
+  const content = await requestSseChatWithRetry({
+    url: endpoint,
+    makeInit: () => ({
+      method: "POST",
+      headers: {
+        accept: "text/event-stream",
+        authorization: `Bearer ${configuration.GENERATION_API_KEY}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(
+        buildOpenRouterMimoCapabilityBody(configuration.LEARNING_MODEL),
+      ),
+    }),
+    deadlineMs: 30_000,
+    attemptTimeoutMs: 12_000,
+  });
+
+  let parsed;
+  try {
+    parsed = JSON.parse(content.trim());
+  } catch {
+    throw new LiveSmokeError("malformed_response");
+  }
+  assertExactObject(parsed, EXPECTED_JSON);
+}
+
+process.exitCode = await runGuardedLiveSmoke({
+  name: "openrouter-mimo",
+  action: main,
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Change

Production generation and the multimodal judge can now be compiled as **OpenRouter-primary** (`xiaomi/mimo-v2.5`) with a **separate Hetzner client** used only after transport failure.

Rebased onto current `origin/main` (`20a79bcf`, the merged transcription/review hotfix from #9). Same PR; not stacked on #10.

Env-only “point the Hetzner client at `https://openrouter.ai/api/v1`” cannot keep a real Hetzner fallback: one client is one base URL, and `JUDGE_FALLBACK_MODEL` is only a second model name on that same URL. The compiler now accepts a dual-provider shape:

- Primary: `GENERATION_PROVIDER=openrouter` / `MULTIMODAL_JUDGE_PROVIDER=openrouter` against OpenRouter
- Fallback: `GENERATION_FALLBACK_*` and `JUDGE_TRANSPORT_FALLBACK_*` against Hetzner
- `JUDGE_FALLBACK_MODEL` is unchanged: same-URL vision model for the **primary** judge
- Hetzner-only production (`GENERATION_PROVIDER=hetzner` / `MULTIMODAL_JUDGE_PROVIDER=hetzner`) still compiles
- Transcription stays OpenRouter Whisper
- `DEMO_MODE` / `fake` providers are unchanged

After a successful hop, persisted provider/model metadata names the provider that **actually answered** (`answeredBy` on semantic raw responses; judge metadata already carries provider/model, and validation now accepts the fallback descriptor).

This PR also adds `scripts/live-smoke-openrouter-mimo.mjs`: a guarded OpenRouter-only generation smoke that matches the real streamed `json_schema` wire (`stream: true`, `Accept: text/event-stream`, `store: false`). It does not hop to Hetzner. The existing Hetzner text/JSON smoke is unchanged and remains the wrong check for this cutover.

## Failure mode

- Timeout / 429 / 5xx / network / unavailable: existing per-client transport retries, then one Hetzner hop, then an honest provider error if Hetzner also fails
- `INVALID_OUTPUT`, schema reject, or terminal 4xx `request_rejected`: **no Hetzner hop**
- The wrapper itself does not invent Learning/Practice/Proof questions or a fake judge score
- The MiMo live smoke retries only 429/5xx/network/timeout, fails closed on schema mismatch or non-event-stream, and never hops to Hetzner

## Left alone (ambiguous or real boundaries)

- **`invokeWithOneRepair` on `main` still calls deterministic semantic fallbacks** after both providers fail. Removing that is #10’s job. This PR does not restack on #10 and does not delete those templates.
- Empty-frame judge still writes authoritative `not_evaluable` / `manualReviewFallbackMultimodalJudgeResultV1` on `main`. Same #10 boundary.
- OpenRouter request shaping omits Hetzner-only `chat_template_kwargs`. If MiMo rejects `json_schema`, that is `INVALID_OUTPUT` and must **not** hop to Hetzner.
- No host, secret rotation, deploy-script, Compose, or GitHub ruleset changes. Operators still have to compile and roll a new `worker.env` to cut over.

## Verification

- [x] Unit or contract tests (`pnpm test`: 728 passed after rebase onto #9, including transport hop, no-hop on `INVALID_OUTPUT`, demo fakes, compiler/config cutover; `pnpm test:live-smoke-contracts` covers the new SSE/json_schema smoke)
- [ ] PostgreSQL integration tests when state or concurrency changed (not required; persistence already stores provider/model strings)
- [ ] Playwright coverage when a user flow changed (none)
- [ ] Threat model or provider data-flow update when a boundary changed (new fallback env fields only; no new stored secret or log field)
- [x] `pnpm audit:secrets`
- [x] No credentials, private repository data or evidence artifacts included

Also green after rebase: `pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm test:live-smoke-contracts`. No live MiMo smoke was run against production.

## Privacy and public output

New worker-only env fields: `GENERATION_FALLBACK_*`, `JUDGE_TRANSPORT_FALLBACK_*`. Fallback API keys are forbidden on web / GitHub Control / base production process files, same as the existing generation/judge keys. `answeredBy` is provider name + model name only — the same metadata already persisted after a successful call.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-061877bd-4d14-4a94-b60e-8e58a29c5e9e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-061877bd-4d14-4a94-b60e-8e58a29c5e9e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

