### PR TITLE
feat: GitHub-hosted production operator on Release published

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,7 @@
 #
 # Create a GitHub Environment named production and add these secret names
 # (not values) before the first real run:
-#   MOBILEUP_SSH_KEY
-#   MOBILEUP_SSH_KNOWN_HOSTS
+#   DEPLOY_SSH_KEY, DEPLOY_SSH_HOST, DEPLOY_SSH_USER, DEPLOY_SSH_KNOWN_HOSTS
 #   GH_APP_ID, GH_WEBHOOK_SECRET, GH_CLIENT_ID, GH_CLIENT_SECRET,
 #   GH_APP_PRIVATE_KEY
 #   KEY_WRAPPING_PRIVATE_KEY, KEY_WRAPPING_PUBLIC_KEY
@@ -196,8 +195,10 @@ jobs:
 
       - name: Stage the managed release through managed-prepare
         env:
-          MOBILEUP_SSH_KEY: ${{ secrets.MOBILEUP_SSH_KEY }}
-          MOBILEUP_SSH_KNOWN_HOSTS: ${{ secrets.MOBILEUP_SSH_KNOWN_HOSTS }}
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_SSH_HOST: ${{ secrets.DEPLOY_SSH_HOST || vars.DEPLOY_SSH_HOST }}
+          DEPLOY_SSH_USER: ${{ secrets.DEPLOY_SSH_USER || vars.DEPLOY_SSH_USER }}
+          DEPLOY_SSH_KNOWN_HOSTS: ${{ secrets.DEPLOY_SSH_KNOWN_HOSTS || vars.DEPLOY_SSH_KNOWN_HOSTS }}
           GH_APP_ID: ${{ secrets.GH_APP_ID }}
           GH_WEBHOOK_SECRET: ${{ secrets.GH_WEBHOOK_SECRET }}
           GH_CLIENT_ID: ${{ secrets.GH_CLIENT_ID }}
@@ -238,7 +239,7 @@ jobs:
             --release-id "$RELEASE_ID" \
             --bundle "$RUNNER_TEMP/slopproof-release/$RELEASE_ID" \
             --compiled-secrets "$RUNNER_TEMP/slopproof-compiled-secrets" \
-            --identity "$RUNNER_TEMP/slopproof-ssh/id_mobileup" \
+            --identity "$RUNNER_TEMP/slopproof-ssh/id_deploy" \
             --image-archive "$RUNNER_TEMP/slopproof-artifacts/slopproof-app-linux-amd64.tar" \
             --image-tag "$IMAGE_TAG" \
             --image-id "$IMAGE_ID" \
@@ -259,8 +260,10 @@ jobs:
       - name: Roll back the named managed release
         env:
           REQUEST_REF: ${{ inputs.ref }}
-          MOBILEUP_SSH_KEY: ${{ secrets.MOBILEUP_SSH_KEY }}
-          MOBILEUP_SSH_KNOWN_HOSTS: ${{ secrets.MOBILEUP_SSH_KNOWN_HOSTS }}
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_SSH_HOST: ${{ secrets.DEPLOY_SSH_HOST || vars.DEPLOY_SSH_HOST }}
+          DEPLOY_SSH_USER: ${{ secrets.DEPLOY_SSH_USER || vars.DEPLOY_SSH_USER }}
+          DEPLOY_SSH_KNOWN_HOSTS: ${{ secrets.DEPLOY_SSH_KNOWN_HOSTS || vars.DEPLOY_SSH_KNOWN_HOSTS }}
         run: |
           set -euo pipefail
           umask 077
@@ -271,4 +274,4 @@ jobs:
           }
           scripts/production-deploy/github-hosted-release.sh managed-rollback \
             --release-id "$REQUEST_REF" \
-            --identity "$RUNNER_TEMP/slopproof-ssh/id_mobileup"
+            --identity "$RUNNER_TEMP/slopproof-ssh/id_deploy"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,274 @@
+# GitHub-hosted production operator driver.
+# Triggers: release published, workflow_dispatch. Never pull_request.
+#
+# Create a GitHub Environment named production and add these secret names
+# (not values) before the first real run:
+#   MOBILEUP_SSH_KEY
+#   MOBILEUP_SSH_KNOWN_HOSTS
+#   GH_APP_ID, GH_WEBHOOK_SECRET, GH_CLIENT_ID, GH_CLIENT_SECRET,
+#   GH_APP_PRIVATE_KEY
+#   KEY_WRAPPING_PRIVATE_KEY, KEY_WRAPPING_PUBLIC_KEY
+#   APP_BASE_URL, DATABASE_URL, SESSION_SECRET, LOG_LEVEL
+#   GENERATION_BASE_URL, GENERATION_API_KEY, LEARNING_MODEL, PRACTICE_MODEL,
+#   PROOF_QUESTION_MODEL, JUDGE_BASE_URL, JUDGE_API_KEY, JUDGE_MODEL,
+#   JUDGE_FALLBACK_MODEL, TRANSCRIPTION_BASE_URL, TRANSCRIPTION_API_KEY,
+#   TRANSCRIPTION_MODEL, S3_CONTROL_ENDPOINT, S3_PUBLIC_ENDPOINT, S3_REGION,
+#   S3_BUCKET, S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY, WORKER_INTERNAL_SECRET,
+#   PROVIDER_PAYLOAD_KEY_BASE64
+# GH_* names exist because Actions forbids secrets named GITHUB_*.
+# This workflow does not cut over production current; see the CMS blocker
+# printed after managed-prepare.
+
+name: production-operator
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Git tag YYYYMMDDTHHMMSSZ, or a git ref to stage
+        required: true
+        type: string
+      mode:
+        description: Stage a managed candidate, or roll back a staged/finalized release
+        required: true
+        type: choice
+        options:
+          - deploy
+          - managed-rollback
+        default: deploy
+
+permissions:
+  contents: read
+
+concurrency:
+  group: slopproof-production-operator
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy:
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'deploy')
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    environment: production
+    env:
+      BUILDX_NO_DEFAULT_ATTESTATIONS: "1"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.release.tag_name || inputs.ref }}
+
+      - name: Resolve release identity
+        env:
+          REQUEST_REF: ${{ github.event.release.tag_name || inputs.ref }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          umask 077
+          [[ $- != *x* ]] || { printf '%s\n' "Shell tracing must be disabled" >&2; exit 1; }
+          commit=$(git rev-parse --verify 'HEAD^{commit}')
+          [[ "$commit" =~ ^[0-9a-f]{40}$ ]] || {
+            printf '%s\n' "Expected a SHA-1 commit" >&2
+            exit 1
+          }
+          if [[ "$REQUEST_REF" =~ ^[0-9]{8}T[0-9]{6}Z$ ]]; then
+            release_id=$REQUEST_REF
+          elif [[ "$EVENT_NAME" == release ]]; then
+            printf '%s\n' "GitHub release tag must be YYYYMMDDTHHMMSSZ" >&2
+            exit 1
+          else
+            release_id=$(date -u +%Y%m%dT%H%M%SZ)
+          fi
+          image_tag="slopproof-app:${commit}-gate9-amd64"
+          {
+            printf 'RELEASE_ID=%s\n' "$release_id"
+            printf 'IMAGE_SOURCE_COMMIT=%s\n' "$commit"
+            printf 'IMAGE_TAG=%s\n' "$image_tag"
+          } >> "$GITHUB_ENV"
+          printf 'Resolved release %s at commit %s\n' "$release_id" "$commit"
+
+      - name: Build linux/amd64 application image
+        env:
+          S3_PUBLIC_ENDPOINT: ${{ secrets.S3_PUBLIC_ENDPOINT }}
+        run: |
+          set -euo pipefail
+          umask 077
+          [[ $- != *x* ]] || { printf '%s\n' "Shell tracing must be disabled" >&2; exit 1; }
+          [[ -n "${S3_PUBLIC_ENDPOINT:-}" ]] || {
+            printf '%s\n' "Missing S3_PUBLIC_ENDPOINT" >&2
+            exit 1
+          }
+          docker build \
+            --platform linux/amd64 \
+            --provenance=false \
+            --sbom=false \
+            --build-arg "S3_PUBLIC_ENDPOINT=${S3_PUBLIC_ENDPOINT}" \
+            --tag "$IMAGE_TAG" \
+            .
+
+      - name: Save the scanned local amd64 archive
+        run: |
+          set -euo pipefail
+          umask 077
+          [[ $- != *x* ]] || { printf '%s\n' "Shell tracing must be disabled" >&2; exit 1; }
+          install -d -m 0700 -- "$RUNNER_TEMP/slopproof-artifacts"
+          platform=$(docker image inspect --format '{{.Os}}/{{.Architecture}}' "$IMAGE_TAG")
+          image_id=$(docker image inspect --format '{{.Id}}' "$IMAGE_TAG")
+          [[ "$platform" == linux/amd64 ]] || {
+            printf '%s\n' "Application image is not linux/amd64" >&2
+            exit 1
+          }
+          [[ "$image_id" =~ ^sha256:[0-9a-f]{64}$ ]] || {
+            printf '%s\n' "Application image ID is invalid" >&2
+            exit 1
+          }
+          docker save --output "$RUNNER_TEMP/slopproof-artifacts/slopproof-app-linux-amd64.tar" "$IMAGE_TAG"
+          chmod 600 -- "$RUNNER_TEMP/slopproof-artifacts/slopproof-app-linux-amd64.tar"
+          printf 'IMAGE_ID=%s\n' "$image_id" >> "$GITHUB_ENV"
+          printf 'Saved linux/amd64 archive for %s\n' "$IMAGE_TAG"
+
+      - name: Scan the amd64 application image
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.IMAGE_TAG }}
+          version: v0.73.0
+          format: json
+          output: ${{ runner.temp }}/slopproof-artifacts/trivy-linux-amd64.json
+          exit-code: "1"
+          vuln-type: os,library
+          severity: HIGH,CRITICAL
+          scanners: vuln
+
+      - name: Generate SPDX SBOM for the amd64 application image
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ${{ env.IMAGE_TAG }}
+          format: spdx-json
+          artifact-name: slopproof-app-linux-amd64
+          output-file: ${{ runner.temp }}/slopproof-artifacts/sbom-linux-amd64.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Bind scan evidence to the image tag
+        run: |
+          set -euo pipefail
+          umask 077
+          [[ $- != *x* ]] || { printf '%s\n' "Shell tracing must be disabled" >&2; exit 1; }
+          chmod 600 -- \
+            "$RUNNER_TEMP/slopproof-artifacts/trivy-linux-amd64.json" \
+            "$RUNNER_TEMP/slopproof-artifacts/sbom-linux-amd64.spdx.json"
+          jq -e --arg tag "$IMAGE_TAG" --arg id "$IMAGE_ID" \
+            '.SchemaVersion == 2 and .ArtifactType == "container_image" and
+             .ArtifactName == $tag and .Metadata.ImageID == $id' \
+            "$RUNNER_TEMP/slopproof-artifacts/trivy-linux-amd64.json" >/dev/null
+          jq -e --arg tag "$IMAGE_TAG" \
+            '.spdxVersion == "SPDX-2.3" and .SPDXID == "SPDXRef-DOCUMENT" and
+             .name == $tag and (.packages | type == "array" and length > 0)' \
+            "$RUNNER_TEMP/slopproof-artifacts/sbom-linux-amd64.spdx.json" >/dev/null
+          printf '%s\n' "Trivy and SPDX evidence are bound to the image tag."
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 10.8.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.13.0
+          cache: pnpm
+
+      - name: Install exact lockfile
+        run: pnpm install --frozen-lockfile
+
+      - name: Ensure rsync is present
+        run: |
+          set -euo pipefail
+          command -v rsync >/dev/null 2>&1 || sudo apt-get install -y rsync
+          [[ $(command -v rsync) == /usr/bin/rsync ]] || {
+            printf '%s\n' "rsync must resolve to /usr/bin/rsync" >&2
+            exit 1
+          }
+
+      - name: Stage the managed release through managed-prepare
+        env:
+          MOBILEUP_SSH_KEY: ${{ secrets.MOBILEUP_SSH_KEY }}
+          MOBILEUP_SSH_KNOWN_HOSTS: ${{ secrets.MOBILEUP_SSH_KNOWN_HOSTS }}
+          GH_APP_ID: ${{ secrets.GH_APP_ID }}
+          GH_WEBHOOK_SECRET: ${{ secrets.GH_WEBHOOK_SECRET }}
+          GH_CLIENT_ID: ${{ secrets.GH_CLIENT_ID }}
+          GH_CLIENT_SECRET: ${{ secrets.GH_CLIENT_SECRET }}
+          GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          KEY_WRAPPING_PRIVATE_KEY: ${{ secrets.KEY_WRAPPING_PRIVATE_KEY }}
+          KEY_WRAPPING_PUBLIC_KEY: ${{ secrets.KEY_WRAPPING_PUBLIC_KEY }}
+          APP_BASE_URL: ${{ secrets.APP_BASE_URL }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
+          LOG_LEVEL: ${{ secrets.LOG_LEVEL }}
+          GENERATION_BASE_URL: ${{ secrets.GENERATION_BASE_URL }}
+          GENERATION_API_KEY: ${{ secrets.GENERATION_API_KEY }}
+          LEARNING_MODEL: ${{ secrets.LEARNING_MODEL }}
+          PRACTICE_MODEL: ${{ secrets.PRACTICE_MODEL }}
+          PROOF_QUESTION_MODEL: ${{ secrets.PROOF_QUESTION_MODEL }}
+          JUDGE_BASE_URL: ${{ secrets.JUDGE_BASE_URL }}
+          JUDGE_API_KEY: ${{ secrets.JUDGE_API_KEY }}
+          JUDGE_MODEL: ${{ secrets.JUDGE_MODEL }}
+          JUDGE_FALLBACK_MODEL: ${{ secrets.JUDGE_FALLBACK_MODEL }}
+          TRANSCRIPTION_BASE_URL: ${{ secrets.TRANSCRIPTION_BASE_URL }}
+          TRANSCRIPTION_API_KEY: ${{ secrets.TRANSCRIPTION_API_KEY }}
+          TRANSCRIPTION_MODEL: ${{ secrets.TRANSCRIPTION_MODEL }}
+          S3_CONTROL_ENDPOINT: ${{ secrets.S3_CONTROL_ENDPOINT }}
+          S3_PUBLIC_ENDPOINT: ${{ secrets.S3_PUBLIC_ENDPOINT }}
+          S3_REGION: ${{ secrets.S3_REGION }}
+          S3_BUCKET: ${{ secrets.S3_BUCKET }}
+          S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+          S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+          WORKER_INTERNAL_SECRET: ${{ secrets.WORKER_INTERNAL_SECRET }}
+          PROVIDER_PAYLOAD_KEY_BASE64: ${{ secrets.PROVIDER_PAYLOAD_KEY_BASE64 }}
+        run: |
+          set -euo pipefail
+          umask 077
+          [[ $- != *x* ]] || { printf '%s\n' "Shell tracing must be disabled" >&2; exit 1; }
+          scripts/production-deploy/github-hosted-release.sh deploy \
+            --repository "$GITHUB_WORKSPACE" \
+            --release-id "$RELEASE_ID" \
+            --bundle "$RUNNER_TEMP/slopproof-release/$RELEASE_ID" \
+            --compiled-secrets "$RUNNER_TEMP/slopproof-compiled-secrets" \
+            --identity "$RUNNER_TEMP/slopproof-ssh/id_mobileup" \
+            --image-archive "$RUNNER_TEMP/slopproof-artifacts/slopproof-app-linux-amd64.tar" \
+            --image-tag "$IMAGE_TAG" \
+            --image-id "$IMAGE_ID" \
+            --image-source-commit "$IMAGE_SOURCE_COMMIT" \
+            --scan-report "$RUNNER_TEMP/slopproof-artifacts/trivy-linux-amd64.json" \
+            --sbom-report "$RUNNER_TEMP/slopproof-artifacts/sbom-linux-amd64.spdx.json"
+
+  rollback:
+    if: github.event_name == 'workflow_dispatch' && inputs.mode == 'managed-rollback'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: production
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Roll back the named managed release
+        env:
+          REQUEST_REF: ${{ inputs.ref }}
+          MOBILEUP_SSH_KEY: ${{ secrets.MOBILEUP_SSH_KEY }}
+          MOBILEUP_SSH_KNOWN_HOSTS: ${{ secrets.MOBILEUP_SSH_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          umask 077
+          [[ $- != *x* ]] || { printf '%s\n' "Shell tracing must be disabled" >&2; exit 1; }
+          [[ "$REQUEST_REF" =~ ^[0-9]{8}T[0-9]{6}Z$ ]] || {
+            printf '%s\n' "managed-rollback requires a YYYYMMDDTHHMMSSZ release ID" >&2
+            exit 1
+          }
+          scripts/production-deploy/github-hosted-release.sh managed-rollback \
+            --release-id "$REQUEST_REF" \
+            --identity "$RUNNER_TEMP/slopproof-ssh/id_mobileup"

--- a/docs/operations/production-deployment.md
+++ b/docs/operations/production-deployment.md
@@ -13,6 +13,16 @@ deliberately named `initial-caddy-cutover`. Subsequent releases use the
 separate managed path below and do not mutate Caddy unless an explicit
 credential or configuration rotation is reviewed.
 
+`.github/workflows/deploy.yml` drives that same managed path from GitHub-hosted
+`ubuntu-latest` using the `production` Environment on Release `published`
+(tag `YYYYMMDDTHHMMSSZ`) or `workflow_dispatch`. It never runs on pull
+requests. It wraps `prepare-release.mjs`, `pnpm production:env`,
+`transfer-release.sh`, and `deploy.sh` through
+`scripts/production-deploy/github-hosted-release.sh`, then stops after
+`managed-prepare`. `migrate-start` still needs the offline CMS recipient and an
+interactive passphrase, which must not enter Actions. Finish backup rehearsal,
+`migrate-start`, and `managed-finalize` on an operator machine as below.
+
 ## Invariants
 
 - `compose.production.yaml` is the only production topology. The local

--- a/scripts/lib/production-deployment.test.mjs
+++ b/scripts/lib/production-deployment.test.mjs
@@ -694,6 +694,10 @@ test("release transfer is Mac- and Ubuntu-compatible, independently trusted and 
   assert.match(transfer, /stat -f '%u:%Lp'/u);
   assert.match(transfer, /bounded 180 ssh[\s\S]*\/usr\/bin\/bash -s/u);
   assert.match(transfer, /\/usr\/bin\/test ! -L "\$target"/u);
+  assert.match(
+    transfer,
+    /REMOTE="\$\{DEPLOY_SSH_USER:-root\}@\$\{DEPLOY_SSH_HOST:-157\.180\.84\.237\}"/u,
+  );
   assert.match(wrapper, /Remote immutable manifest hash mismatch/u);
   assert.match(wrapper, /Remote source content mismatch/u);
   assert.match(wrapper, /Remote artifact content mismatch/u);
@@ -802,11 +806,13 @@ test("GitHub-hosted operator wraps transfer and stops before CMS decrypt", () =>
 
   assert.match(driver, /^umask 077$/mu);
   assert.match(driver, /\[\[ \$- != \*x\* \]\]/u);
-  assert.match(driver, /REMOTE='root@157\.180\.84\.237'/u);
-  assert.equal(
-    /REMOTE='root@157\.180\.84\.237'/u.exec(transfer)?.[0],
-    /REMOTE='root@157\.180\.84\.237'/u.exec(driver)?.[0],
+  assert.match(driver, /DEPLOY_SSH_HOST/u);
+  assert.match(driver, /DEPLOY_SSH_USER:-root/u);
+  assert.match(
+    transfer,
+    /REMOTE="\$\{DEPLOY_SSH_USER:-root\}@\$\{DEPLOY_SSH_HOST:-157\.180\.84\.237\}"/u,
   );
+  assert.doesNotMatch(driver, /mobileup/iu);
   assert.match(driver, /prepare-release\.mjs" create/u);
   assert.match(driver, /pnpm production:env -- "\$output"/u);
   assert.match(driver, /transfer-release\.sh/u);

--- a/scripts/lib/production-deployment.test.mjs
+++ b/scripts/lib/production-deployment.test.mjs
@@ -793,3 +793,45 @@ test("Caddy credential unit disables persistent core dumps", () => {
   );
   assert.match(dropin, /^LimitCORE=0$/mu);
 });
+
+test("GitHub-hosted operator wraps transfer and stops before CMS decrypt", () => {
+  const driver = read("scripts/production-deploy/github-hosted-release.sh");
+  const transfer = read("scripts/production-deploy/transfer-release.sh");
+  const decrypt = read("scripts/production-backup/decrypt-cms-stream.sh");
+  const runbook = read("docs/operations/production-deployment.md");
+
+  assert.match(driver, /^umask 077$/mu);
+  assert.match(driver, /\[\[ \$- != \*x\* \]\]/u);
+  assert.match(driver, /REMOTE='root@157\.180\.84\.237'/u);
+  assert.equal(
+    /REMOTE='root@157\.180\.84\.237'/u.exec(transfer)?.[0],
+    /REMOTE='root@157\.180\.84\.237'/u.exec(driver)?.[0],
+  );
+  assert.match(driver, /prepare-release\.mjs" create/u);
+  assert.match(driver, /pnpm production:env -- "\$output"/u);
+  assert.match(driver, /transfer-release\.sh/u);
+  assert.match(driver, /StrictHostKeyChecking=yes/u);
+  assert.match(driver, /Operator outputs must stay outside the git checkout/u);
+  assert.match(driver, /remote_deploy 180 "\$CURRENT_DEPLOY" preflight/u);
+  assert.match(
+    driver,
+    /remote_deploy 1800 "\$incoming_script" image-stage "\$release_id"/u,
+  );
+  assert.match(
+    driver,
+    /remote_deploy 300 "\$incoming_script" postgres-only "\$release_id"/u,
+  );
+  assert.match(
+    driver,
+    /remote_deploy 180 "\$incoming_script" managed-prepare "\$release_id"/u,
+  );
+  assert.match(driver, /managed-rollback "\$release_id"/u);
+  assert.doesNotMatch(driver, /remote_deploy \d+ .*migrate-start/u);
+  assert.doesNotMatch(driver, /backup-compose/u);
+  assert.doesNotMatch(driver, /pg_dump --/u);
+  assert.match(driver, /Refusing migrate-start/u);
+  assert.match(driver, /Do not pg_dump onto the runner/u);
+  assert.match(decrypt, /< \/dev\/tty/u);
+  assert.match(runbook, /github-hosted-release\.sh/u);
+  assert.match(runbook, /stops after[\s\S]*managed-prepare/u);
+});

--- a/scripts/lib/production-operations.test.mjs
+++ b/scripts/lib/production-operations.test.mjs
@@ -128,6 +128,53 @@ test("supply-chain workflow pins actions and fails high-risk image findings", ()
   assert.match(workflow, /severity: HIGH,CRITICAL/u);
 });
 
+test("production operator workflow is GitHub-hosted, environment-gated and never a pull_request", () => {
+  const workflow = read(".github/workflows/deploy.yml");
+  const ci = read(".github/workflows/ci.yml");
+  const onBlock = workflow.slice(
+    workflow.search(/^on:/mu),
+    workflow.search(/^permissions:/mu),
+  );
+  const actionReferences = [...workflow.matchAll(/uses:\s+([^\s#]+)/gu)].map(
+    (match) => match[1],
+  );
+
+  assert.match(onBlock, /release:[\s\S]*types: \[published\]/u);
+  assert.match(onBlock, /workflow_dispatch:/u);
+  assert.doesNotMatch(onBlock, /pull_request(?:_target)?/u);
+  assert.equal(
+    [...workflow.matchAll(/^    runs-on: ubuntu-latest$/gmu)].length,
+    2,
+  );
+  assert.equal(
+    [...workflow.matchAll(/^    environment: production$/gmu)].length,
+    2,
+  );
+  assert.match(workflow, /cancel-in-progress: false/u);
+  assert.match(workflow, /permissions:\n  contents: read/u);
+  const supply = read(".github/workflows/supply-chain.yml");
+  assert.ok(actionReferences.length >= 5);
+  for (const reference of actionReferences) {
+    assert.match(reference, /^[^@\s]+@[0-9a-f]{40}$/u);
+    assert.ok(ci.includes(reference) || supply.includes(reference), reference);
+  }
+  assert.match(
+    workflow,
+    /scripts\/production-deploy\/github-hosted-release\.sh deploy/u,
+  );
+  assert.match(
+    workflow,
+    /scripts\/production-deploy\/github-hosted-release\.sh managed-rollback/u,
+  );
+  assert.match(workflow, /--platform linux\/amd64/u);
+  assert.match(workflow, /--provenance=false/u);
+  assert.match(workflow, /upload-artifact: false/u);
+  assert.doesNotMatch(workflow, /pg_dump|run-backup-rehearsal|migrate-start/u);
+  assert.match(workflow, /MOBILEUP_SSH_KEY/u);
+  assert.match(workflow, /GH_APP_PRIVATE_KEY/u);
+  assert.match(workflow, /KEY_WRAPPING_PRIVATE_KEY/u);
+});
+
 test("the production application base image is pinned by multi-arch digest", () => {
   const dockerfile = read("Dockerfile");
   const stages = [

--- a/scripts/lib/production-operations.test.mjs
+++ b/scripts/lib/production-operations.test.mjs
@@ -170,9 +170,12 @@ test("production operator workflow is GitHub-hosted, environment-gated and never
   assert.match(workflow, /--provenance=false/u);
   assert.match(workflow, /upload-artifact: false/u);
   assert.doesNotMatch(workflow, /pg_dump|run-backup-rehearsal|migrate-start/u);
-  assert.match(workflow, /MOBILEUP_SSH_KEY/u);
+  assert.match(workflow, /DEPLOY_SSH_KEY/u);
+  assert.match(workflow, /DEPLOY_SSH_HOST/u);
+  assert.match(workflow, /DEPLOY_SSH_USER/u);
   assert.match(workflow, /GH_APP_PRIVATE_KEY/u);
   assert.match(workflow, /KEY_WRAPPING_PRIVATE_KEY/u);
+  assert.doesNotMatch(workflow, /mobileup/iu);
 });
 
 test("the production application base image is pinned by multi-arch digest", () => {

--- a/scripts/production-deploy/github-hosted-release.sh
+++ b/scripts/production-deploy/github-hosted-release.sh
@@ -1,0 +1,383 @@
+#!/usr/bin/env bash
+# GitHub-hosted ubuntu-latest driver for the existing production operator path.
+# Wraps prepare-release.mjs, pnpm production:env, transfer-release.sh, and
+# deploy.sh. It never implements a second runner, never runs on pull_request,
+# and never writes compiler outputs into the git checkout.
+#
+# Environment secret names (values never belong in this repository):
+#   MOBILEUP_SSH_KEY
+#   MOBILEUP_SSH_KNOWN_HOSTS
+#   GH_APP_ID GH_WEBHOOK_SECRET GH_CLIENT_ID GH_CLIENT_SECRET GH_APP_PRIVATE_KEY
+#   KEY_WRAPPING_PRIVATE_KEY KEY_WRAPPING_PUBLIC_KEY
+#   APP_BASE_URL DATABASE_URL SESSION_SECRET LOG_LEVEL
+#   GENERATION_BASE_URL GENERATION_API_KEY LEARNING_MODEL PRACTICE_MODEL
+#   PROOF_QUESTION_MODEL JUDGE_BASE_URL JUDGE_API_KEY JUDGE_MODEL
+#   JUDGE_FALLBACK_MODEL TRANSCRIPTION_BASE_URL TRANSCRIPTION_API_KEY
+#   TRANSCRIPTION_MODEL S3_CONTROL_ENDPOINT S3_PUBLIC_ENDPOINT S3_REGION
+#   S3_BUCKET S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY WORKER_INTERNAL_SECRET
+#   PROVIDER_PAYLOAD_KEY_BASE64
+#
+# GH_* names exist because GitHub forbids Environment secrets named GITHUB_*.
+# The compiler still receives GITHUB_APP_ID, GITHUB_WEBHOOK_SECRET,
+# GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, and path-based PEM inputs.
+#
+# This driver stops after managed-prepare. migrate-start requires a verified
+# CMS backup receipt. decrypt-cms-stream.sh reads the backup recipient
+# passphrase from /dev/tty and the private key must remain
+# -----BEGIN ENCRYPTED PRIVATE KEY-----. That key is not representable as an
+# Actions secret without putting backup recovery material on ubuntu-latest.
+set -euo pipefail
+IFS=$'\n\t'
+umask 077
+[[ $- != *x* ]] || {
+  printf '%s\n' "Shell tracing must be disabled" >&2
+  exit 1
+}
+
+readonly REMOTE='root@157.180.84.237'
+readonly CURRENT_DEPLOY='/opt/slopproof/current/scripts/production-deploy/deploy.sh'
+
+die() {
+  printf '%s\n' "$1" >&2
+  exit 1
+}
+
+bounded() {
+  local seconds=$1
+  shift
+  perl -e 'alarm shift; exec @ARGV or exit 127' "$seconds" "$@"
+}
+
+require_release_id() {
+  [[ "$1" =~ ^[0-9]{8}T[0-9]{6}Z$ ]] || die "Invalid release ID"
+}
+
+require_absolute_dir() {
+  [[ "$1" == /* && -d "$1" && ! -L "$1" ]] || die "$2 is not a safe directory"
+}
+
+require_absolute_file() {
+  [[ "$1" == /* && -f "$1" && ! -L "$1" ]] || die "$2 is not a safe file"
+}
+
+require_absent() {
+  [[ ! -e "$1" && ! -L "$1" ]] || die "$2 already exists"
+}
+
+require_env() {
+  local name=$1
+  [[ -n "${!name:-}" ]] || die "Missing $name"
+}
+
+write_owner_file() {
+  local path=$1 mode=$2
+  require_absent "$path" "$path"
+  install -m "$mode" /dev/null "$path"
+  tr -d '\r' > "$path"
+  chmod "$mode" -- "$path"
+  [[ -s "$path" ]] || die "Wrote an empty protected file"
+}
+
+incoming_deploy() {
+  printf '%s' "/opt/slopproof/releases/$1.incoming/source/scripts/production-deploy/deploy.sh"
+}
+
+final_deploy() {
+  printf '%s' "/opt/slopproof/releases/$1/source/scripts/production-deploy/deploy.sh"
+}
+
+ssh_options_from_identity() {
+  local identity=$1
+  ssh_options=(
+    -i "$identity"
+    -o IdentitiesOnly=yes
+    -o BatchMode=yes
+    -o ConnectTimeout=10
+    -o ServerAliveInterval=10
+    -o ServerAliveCountMax=3
+    -o StrictHostKeyChecking=yes
+  )
+}
+
+install_ssh_material() {
+  local identity=$1
+  require_env MOBILEUP_SSH_KEY
+  require_env MOBILEUP_SSH_KNOWN_HOSTS
+  require_absent "$identity" "SSH identity"
+  install -d -m 0700 -- "$(dirname "$identity")"
+  printf '%s' "$MOBILEUP_SSH_KEY" | write_owner_file "$identity" 600
+  MOBILEUP_SSH_KEY=''
+  unset MOBILEUP_SSH_KEY
+  install -d -m 0700 -- "${HOME:?}/.ssh"
+  chmod 700 -- "$HOME/.ssh"
+  rm -f -- "$HOME/.ssh/known_hosts"
+  printf '%s' "$MOBILEUP_SSH_KNOWN_HOSTS" | write_owner_file "$HOME/.ssh/known_hosts" 600
+  MOBILEUP_SSH_KNOWN_HOSTS=''
+  unset MOBILEUP_SSH_KNOWN_HOSTS
+}
+
+ssh_mobileup() {
+  local seconds=$1
+  shift
+  bounded "$seconds" ssh "${ssh_options[@]}" "$REMOTE" "$@"
+}
+
+remote_deploy() {
+  local seconds=$1 script=$2
+  shift 2
+  [[ "$script" == /opt/slopproof/* ]] || die "Refusing to execute a non-release deploy script"
+  ssh_mobileup "$seconds" "$script" "$@"
+}
+
+unset_compiler_secrets() {
+  unset \
+    GH_APP_PRIVATE_KEY \
+    KEY_WRAPPING_PRIVATE_KEY \
+    KEY_WRAPPING_PUBLIC_KEY \
+    APP_BASE_URL \
+    DATABASE_URL \
+    SESSION_SECRET \
+    LOG_LEVEL \
+    GH_APP_ID \
+    GH_WEBHOOK_SECRET \
+    GH_CLIENT_ID \
+    GH_CLIENT_SECRET \
+    GITHUB_APP_ID \
+    GITHUB_WEBHOOK_SECRET \
+    GITHUB_CLIENT_ID \
+    GITHUB_CLIENT_SECRET \
+    GENERATION_BASE_URL \
+    GENERATION_API_KEY \
+    LEARNING_MODEL \
+    PRACTICE_MODEL \
+    PROOF_QUESTION_MODEL \
+    JUDGE_BASE_URL \
+    JUDGE_API_KEY \
+    JUDGE_MODEL \
+    JUDGE_FALLBACK_MODEL \
+    TRANSCRIPTION_BASE_URL \
+    TRANSCRIPTION_API_KEY \
+    TRANSCRIPTION_MODEL \
+    S3_CONTROL_ENDPOINT \
+    S3_PUBLIC_ENDPOINT \
+    S3_REGION \
+    S3_BUCKET \
+    S3_ACCESS_KEY_ID \
+    S3_SECRET_ACCESS_KEY \
+    WORKER_INTERNAL_SECRET \
+    PROVIDER_PAYLOAD_KEY_BASE64
+}
+
+compile_production_secrets() {
+  local repository=$1 output=$2 key_root=$3
+  require_absolute_dir "$repository" "repository"
+  require_absent "$output" "compiled secret directory"
+  require_absent "$key_root" "compiler key directory"
+
+  require_env GH_APP_PRIVATE_KEY
+  require_env KEY_WRAPPING_PRIVATE_KEY
+  require_env KEY_WRAPPING_PUBLIC_KEY
+  require_env APP_BASE_URL
+  require_env DATABASE_URL
+  require_env SESSION_SECRET
+  require_env LOG_LEVEL
+  require_env GH_APP_ID
+  require_env GH_WEBHOOK_SECRET
+  require_env GH_CLIENT_ID
+  require_env GH_CLIENT_SECRET
+  require_env GENERATION_BASE_URL
+  require_env GENERATION_API_KEY
+  require_env LEARNING_MODEL
+  require_env PRACTICE_MODEL
+  require_env PROOF_QUESTION_MODEL
+  require_env JUDGE_BASE_URL
+  require_env JUDGE_API_KEY
+  require_env JUDGE_MODEL
+  require_env JUDGE_FALLBACK_MODEL
+  require_env TRANSCRIPTION_BASE_URL
+  require_env TRANSCRIPTION_API_KEY
+  require_env TRANSCRIPTION_MODEL
+  require_env S3_CONTROL_ENDPOINT
+  require_env S3_PUBLIC_ENDPOINT
+  require_env S3_REGION
+  require_env S3_BUCKET
+  require_env S3_ACCESS_KEY_ID
+  require_env S3_SECRET_ACCESS_KEY
+  require_env WORKER_INTERNAL_SECRET
+  require_env PROVIDER_PAYLOAD_KEY_BASE64
+
+  install -d -m 0700 -- "$key_root"
+  printf '%s' "$GH_APP_PRIVATE_KEY" | write_owner_file "$key_root/github-app.pem" 600
+  printf '%s' "$KEY_WRAPPING_PRIVATE_KEY" | write_owner_file "$key_root/wrapping-private.pem" 600
+  printf '%s' "$KEY_WRAPPING_PUBLIC_KEY" | write_owner_file "$key_root/wrapping-public.pem" 644
+  GH_APP_PRIVATE_KEY=''
+  KEY_WRAPPING_PRIVATE_KEY=''
+  KEY_WRAPPING_PUBLIC_KEY=''
+  unset GH_APP_PRIVATE_KEY KEY_WRAPPING_PRIVATE_KEY KEY_WRAPPING_PUBLIC_KEY
+
+  install -d -m 0700 -- "$output"
+
+  (
+    cd "$repository"
+    NODE_ENV=production \
+      DEMO_MODE=false \
+      DEMO_FAKE_MEDIA=false \
+      GITHUB_ADAPTER=octokit \
+      GENERATION_PROVIDER=hetzner \
+      MULTIMODAL_JUDGE_PROVIDER=hetzner \
+      TRANSCRIPTION_PROVIDER=openrouter \
+      EVIDENCE_STORAGE_PROVIDER=s3 \
+      KEY_WRAPPING_PROVIDER=local \
+      WORKER_INTERNAL_URL=http://worker:4001 \
+      WORKER_HOST=0.0.0.0 \
+      WORKER_PORT=4001 \
+      FFMPEG_PATH=/usr/bin/ffmpeg \
+      FFPROBE_PATH=/usr/bin/ffprobe \
+      GITHUB_PRIVATE_KEY_CONTAINER_PATH=/run/secrets/github-app.pem \
+      KEY_WRAPPING_PUBLIC_KEY_CONTAINER_PATH=/run/secrets/wrapping-public.pem \
+      KEY_WRAPPING_PRIVATE_KEY_CONTAINER_PATH=/run/secrets/wrapping-private.pem \
+      GITHUB_PRIVATE_KEY_PATH="$key_root/github-app.pem" \
+      KEY_WRAPPING_PRIVATE_KEY_PATH="$key_root/wrapping-private.pem" \
+      KEY_WRAPPING_PUBLIC_KEY_PATH="$key_root/wrapping-public.pem" \
+      GITHUB_APP_ID="$GH_APP_ID" \
+      GITHUB_WEBHOOK_SECRET="$GH_WEBHOOK_SECRET" \
+      GITHUB_CLIENT_ID="$GH_CLIENT_ID" \
+      GITHUB_CLIENT_SECRET="$GH_CLIENT_SECRET" \
+      pnpm production:env -- "$output"
+  )
+
+  unset_compiler_secrets
+}
+
+create_release_bundle() {
+  local repository=$1 output=$2 release_id=$3 image_archive=$4 image_tag=$5
+  local image_id=$6 image_source_commit=$7 scan_report=$8 sbom_report=$9
+  require_absent "$output" "release bundle"
+  node "$repository/scripts/production-deploy/prepare-release.mjs" create \
+    --repository "$repository" \
+    --output "$output" \
+    --release-id "$release_id" \
+    --image-archive "$image_archive" \
+    --image-tag "$image_tag" \
+    --image-id "$image_id" \
+    --image-source-commit "$image_source_commit" \
+    --scan-report "$scan_report" \
+    --sbom-report "$sbom_report"
+}
+
+transfer_release() {
+  local repository=$1 bundle=$2 compiled_secrets=$3 identity=$4
+  local image_id image_tag image_source_commit archive_sha256 scan_sha256 sbom_sha256
+  image_id=$(jq -er '.image.id' "$bundle/source/.slopproof-release.json")
+  image_tag=$(jq -er '.image.tag' "$bundle/source/.slopproof-release.json")
+  image_source_commit=$(jq -er '.image.sourceCommit' "$bundle/source/.slopproof-release.json")
+  archive_sha256=$(jq -er '.image.archiveSha256' "$bundle/source/.slopproof-release.json")
+  scan_sha256=$(jq -er '.image.scanReportSha256' "$bundle/source/.slopproof-release.json")
+  sbom_sha256=$(jq -er '.image.sbomReportSha256' "$bundle/source/.slopproof-release.json")
+  "$repository/scripts/production-deploy/transfer-release.sh" \
+    --bundle "$bundle" \
+    --compiled-secrets "$compiled_secrets" \
+    --identity "$identity" \
+    --trusted-checkout "$repository" \
+    --expected-image-id "$image_id" \
+    --expected-image-tag "$image_tag" \
+    --expected-image-source-commit "$image_source_commit" \
+    --expected-archive-sha256 "$archive_sha256" \
+    --expected-scan-sha256 "$scan_sha256" \
+    --expected-sbom-sha256 "$sbom_sha256"
+}
+
+print_cms_blocker() {
+  printf '%s\n' \
+    "Staged the managed candidate through managed-prepare." \
+    "Refusing migrate-start: the backup recipient private key is an encrypted PEM whose passphrase is read from /dev/tty by scripts/production-backup/decrypt-cms-stream.sh." \
+    "Putting that key or passphrase in the production Environment would place backup recovery material on GitHub-hosted ubuntu-latest and in Actions logs' secret store." \
+    "Do not pg_dump onto the runner. Complete run-backup-rehearsal.sh, verify-and-transfer-backup.sh, deploy.sh migrate-start, and deploy.sh managed-finalize from an operator machine."
+  printf '%s\n' \
+    '::warning title=Production current unchanged::migrate-start still requires the offline CMS recipient passphrase on a TTY. This job staged through managed-prepare only.'
+}
+
+run_deploy() {
+  [[ $# -eq 22 && $1 == --repository && $3 == --release-id && $5 == --bundle &&
+    $7 == --compiled-secrets && $9 == --identity && ${11} == --image-archive &&
+    ${13} == --image-tag && ${15} == --image-id &&
+    ${17} == --image-source-commit && ${19} == --scan-report &&
+    ${21} == --sbom-report ]] ||
+    die "Usage: github-hosted-release.sh deploy --repository ABS --release-id ID --bundle ABS --compiled-secrets ABS --identity ABS --image-archive ABS --image-tag TAG --image-id ID --image-source-commit SHA --scan-report ABS --sbom-report ABS"
+
+  local repository=$2 release_id=$4 bundle=$6 compiled_secrets=$8 identity=${10}
+  local image_archive=${12} image_tag=${14} image_id=${16}
+  local image_source_commit=${18} scan_report=${20} sbom_report=${22}
+  local key_root incoming_script
+  require_release_id "$release_id"
+  require_absolute_dir "$repository" "repository"
+  [[ "$bundle" == /* && "$compiled_secrets" == /* && "$identity" == /* &&
+    "$image_archive" == /* && "$scan_report" == /* && "$sbom_report" == /* ]] ||
+    die "All local paths must be absolute"
+  [[ "$bundle" != "$repository" && "$bundle" != "$repository"/* &&
+    "$compiled_secrets" != "$repository" && "$compiled_secrets" != "$repository"/* &&
+    "$identity" != "$repository" && "$identity" != "$repository"/* ]] ||
+    die "Operator outputs must stay outside the git checkout"
+  require_absolute_file "$image_archive" "image archive"
+  require_absolute_file "$scan_report" "Trivy report"
+  require_absolute_file "$sbom_report" "SPDX report"
+  [[ -z $(git -C "$repository" status --porcelain=v1 --untracked-files=all) ]] ||
+    die "Trusted checkout is not clean"
+
+  key_root="$(dirname "$compiled_secrets")/compiler-keys"
+  COMPILED_SECRETS_CLEANUP=$compiled_secrets
+  KEY_ROOT_CLEANUP=$key_root
+  IDENTITY_CLEANUP=$identity
+  trap 'rm -rf -- "${COMPILED_SECRETS_CLEANUP:-}" "${KEY_ROOT_CLEANUP:-}"; rm -f -- "${IDENTITY_CLEANUP:-}"' EXIT
+
+  create_release_bundle "$repository" "$bundle" "$release_id" \
+    "$image_archive" "$image_tag" "$image_id" "$image_source_commit" \
+    "$scan_report" "$sbom_report"
+  compile_production_secrets "$repository" "$compiled_secrets" "$key_root"
+  install_ssh_material "$identity"
+  ssh_options_from_identity "$identity"
+
+  ssh_mobileup 60 test -x "$CURRENT_DEPLOY"
+  remote_deploy 180 "$CURRENT_DEPLOY" preflight
+  transfer_release "$repository" "$bundle" "$compiled_secrets" "$identity"
+  incoming_script=$(incoming_deploy "$release_id")
+  ssh_mobileup 60 test -x "$incoming_script"
+  remote_deploy 1800 "$incoming_script" image-stage "$release_id"
+  remote_deploy 300 "$incoming_script" postgres-only "$release_id"
+  remote_deploy 180 "$incoming_script" managed-prepare "$release_id"
+  print_cms_blocker
+}
+
+run_managed_rollback() {
+  [[ $# -eq 4 && $1 == --release-id && $3 == --identity ]] ||
+    die "Usage: github-hosted-release.sh managed-rollback --release-id ID --identity ABS"
+  local release_id=$2 identity=$4 script
+  require_release_id "$release_id"
+  [[ "$identity" == /* ]] || die "SSH identity must be absolute"
+  IDENTITY_CLEANUP=$identity
+  trap 'rm -f -- "${IDENTITY_CLEANUP:-}"' EXIT
+  install_ssh_material "$identity"
+  ssh_options_from_identity "$identity"
+  if ssh_mobileup 60 test -x "$(incoming_deploy "$release_id")"; then
+    script=$(incoming_deploy "$release_id")
+  elif ssh_mobileup 60 test -x "$(final_deploy "$release_id")"; then
+    script=$(final_deploy "$release_id")
+  else
+    die "Release deploy.sh is absent on mobileup"
+  fi
+  remote_deploy 900 "$script" managed-rollback "$release_id"
+}
+
+case "${1:-}" in
+  deploy)
+    shift
+    run_deploy "$@"
+    ;;
+  managed-rollback)
+    shift
+    run_managed_rollback "$@"
+    ;;
+  *)
+    die "Expected deploy or managed-rollback"
+    ;;
+esac

--- a/scripts/production-deploy/github-hosted-release.sh
+++ b/scripts/production-deploy/github-hosted-release.sh
@@ -5,8 +5,7 @@
 # and never writes compiler outputs into the git checkout.
 #
 # Environment secret names (values never belong in this repository):
-#   MOBILEUP_SSH_KEY
-#   MOBILEUP_SSH_KNOWN_HOSTS
+#   DEPLOY_SSH_KEY DEPLOY_SSH_HOST DEPLOY_SSH_USER DEPLOY_SSH_KNOWN_HOSTS
 #   GH_APP_ID GH_WEBHOOK_SECRET GH_CLIENT_ID GH_CLIENT_SECRET GH_APP_PRIVATE_KEY
 #   KEY_WRAPPING_PRIVATE_KEY KEY_WRAPPING_PUBLIC_KEY
 #   APP_BASE_URL DATABASE_URL SESSION_SECRET LOG_LEVEL
@@ -34,8 +33,8 @@ umask 077
   exit 1
 }
 
-readonly REMOTE='root@157.180.84.237'
 readonly CURRENT_DEPLOY='/opt/slopproof/current/scripts/production-deploy/deploy.sh'
+REMOTE=''
 
 die() {
   printf '%s\n' "$1" >&2
@@ -99,26 +98,38 @@ ssh_options_from_identity() {
   )
 }
 
+resolve_deploy_remote() {
+  local user=${DEPLOY_SSH_USER:-root}
+  require_env DEPLOY_SSH_HOST
+  [[ "$user" =~ ^[A-Za-z_][A-Za-z0-9_-]*$ ]] || die "Invalid DEPLOY_SSH_USER"
+  [[ "$DEPLOY_SSH_HOST" =~ ^[A-Za-z0-9._:\[\]-]+$ ]] || die "Invalid DEPLOY_SSH_HOST"
+  REMOTE="$user@$DEPLOY_SSH_HOST"
+  export DEPLOY_SSH_USER=$user
+  export DEPLOY_SSH_HOST
+}
+
 install_ssh_material() {
   local identity=$1
-  require_env MOBILEUP_SSH_KEY
-  require_env MOBILEUP_SSH_KNOWN_HOSTS
+  require_env DEPLOY_SSH_KEY
+  require_env DEPLOY_SSH_KNOWN_HOSTS
   require_absent "$identity" "SSH identity"
+  resolve_deploy_remote
   install -d -m 0700 -- "$(dirname "$identity")"
-  printf '%s' "$MOBILEUP_SSH_KEY" | write_owner_file "$identity" 600
-  MOBILEUP_SSH_KEY=''
-  unset MOBILEUP_SSH_KEY
+  printf '%s' "$DEPLOY_SSH_KEY" | write_owner_file "$identity" 600
+  DEPLOY_SSH_KEY=''
+  unset DEPLOY_SSH_KEY
   install -d -m 0700 -- "${HOME:?}/.ssh"
   chmod 700 -- "$HOME/.ssh"
   rm -f -- "$HOME/.ssh/known_hosts"
-  printf '%s' "$MOBILEUP_SSH_KNOWN_HOSTS" | write_owner_file "$HOME/.ssh/known_hosts" 600
-  MOBILEUP_SSH_KNOWN_HOSTS=''
-  unset MOBILEUP_SSH_KNOWN_HOSTS
+  printf '%s' "$DEPLOY_SSH_KNOWN_HOSTS" | write_owner_file "$HOME/.ssh/known_hosts" 600
+  DEPLOY_SSH_KNOWN_HOSTS=''
+  unset DEPLOY_SSH_KNOWN_HOSTS
 }
 
-ssh_mobileup() {
+ssh_production() {
   local seconds=$1
   shift
+  [[ -n "$REMOTE" ]] || die "Production SSH remote is unset"
   bounded "$seconds" ssh "${ssh_options[@]}" "$REMOTE" "$@"
 }
 
@@ -126,7 +137,7 @@ remote_deploy() {
   local seconds=$1 script=$2
   shift 2
   [[ "$script" == /opt/slopproof/* ]] || die "Refusing to execute a non-release deploy script"
-  ssh_mobileup "$seconds" "$script" "$@"
+  ssh_production "$seconds" "$script" "$@"
 }
 
 unset_compiler_secrets() {
@@ -337,11 +348,11 @@ run_deploy() {
   install_ssh_material "$identity"
   ssh_options_from_identity "$identity"
 
-  ssh_mobileup 60 test -x "$CURRENT_DEPLOY"
+  ssh_production 60 test -x "$CURRENT_DEPLOY"
   remote_deploy 180 "$CURRENT_DEPLOY" preflight
   transfer_release "$repository" "$bundle" "$compiled_secrets" "$identity"
   incoming_script=$(incoming_deploy "$release_id")
-  ssh_mobileup 60 test -x "$incoming_script"
+  ssh_production 60 test -x "$incoming_script"
   remote_deploy 1800 "$incoming_script" image-stage "$release_id"
   remote_deploy 300 "$incoming_script" postgres-only "$release_id"
   remote_deploy 180 "$incoming_script" managed-prepare "$release_id"
@@ -358,12 +369,12 @@ run_managed_rollback() {
   trap 'rm -f -- "${IDENTITY_CLEANUP:-}"' EXIT
   install_ssh_material "$identity"
   ssh_options_from_identity "$identity"
-  if ssh_mobileup 60 test -x "$(incoming_deploy "$release_id")"; then
+  if ssh_production 60 test -x "$(incoming_deploy "$release_id")"; then
     script=$(incoming_deploy "$release_id")
-  elif ssh_mobileup 60 test -x "$(final_deploy "$release_id")"; then
+  elif ssh_production 60 test -x "$(final_deploy "$release_id")"; then
     script=$(final_deploy "$release_id")
   else
-    die "Release deploy.sh is absent on mobileup"
+    die "Release deploy.sh is absent on the production host"
   fi
   remote_deploy 900 "$script" managed-rollback "$release_id"
 }

--- a/scripts/production-deploy/transfer-release.sh
+++ b/scripts/production-deploy/transfer-release.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 IFS=$'\n\t'
 umask 077
 
-readonly REMOTE='root@157.180.84.237'
+# Local operators leave DEPLOY_SSH_* unset and keep the existing host default.
+readonly REMOTE="${DEPLOY_SSH_USER:-root}@${DEPLOY_SSH_HOST:-157.180.84.237}"
 readonly RELEASES_ROOT='/opt/slopproof/releases'
 readonly SECRET_ROOT='/etc/slopproof/secrets'
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Change

Adds the smallest GitHub-hosted driver that can actually wrap the existing SlopProof operator path. New branch off `main`. Not stacked on #9, #10, or #11. Does not merge, does not publish a release, and does not run a live deploy.

`.github/workflows/deploy.yml` runs on GitHub-hosted `ubuntu-latest` with `environment: production`:

- `on.release.types: [published]`
- `on.workflow_dispatch` with a tag/ref input and `deploy` / `managed-rollback`
- no `pull_request` / `pull_request_target`

It builds the allowlisted release bundle and local linux/amd64 archive the way `prepare-release.mjs` already does, compiles the nine-file secret set outside the git checkout, then SSHs/rsyncs through the existing `transfer-release.sh` and `deploy.sh` phases: `preflight`, `install` (inside transfer), `image-stage`, `postgres-only`, `managed-prepare`.

SSH on this new Actions surface uses `DEPLOY_SSH_KEY`, `DEPLOY_SSH_HOST`, and `DEPLOY_SSH_USER` (default `root`). The host is not hardcoded in the workflow. `transfer-release.sh` still defaults to its existing local operator remote when those variables are unset, and honors the same override when the workflow sets them. Existing operator scripts are otherwise unchanged.

This does **not** deploy until Pascal creates the `production` Environment secrets below and publishes a Release whose tag is `YYYYMMDDTHHMMSSZ` (or uses `workflow_dispatch`). Even then, the workflow does not change `current`: it stops after `managed-prepare`.

## CMS blocker (why it cannot call `migrate-start`)

`deploy.sh migrate-start` requires `/opt/slopproof/shared/backup-receipt-<id>.verified.json` from `scripts/production-backup/verify-receipt.mjs`. That receipt is produced only after `run-backup-rehearsal.sh` streams `pg_dump` into CMS encryption and decrypts that **same** ciphertext into the tmpfs restore container.

`decrypt-cms-stream.sh` refuses anything except `-----BEGIN ENCRYPTED PRIVATE KEY-----` and reads the passphrase from `/dev/tty`. The runbook already forbids that key from entering CI, the VM, or the environment. Putting the key or passphrase in Actions would place backup-recovery material on public `ubuntu-latest` runners. Host-side plaintext `pg_dump` is also forbidden (unencrypted root fs). A second dump/restore that never decrypts the CMS artifact would not prove the backup is restorable.

So this PR does not weaken that boundary, does not `pg_dump` onto GitHub-hosted disk, and does not invent a second runner. After a successful stage, finish locally:

1. `scripts/production-backup/run-backup-rehearsal.sh`
2. `scripts/production-deploy/verify-and-transfer-backup.sh`
3. `deploy.sh migrate-start`
4. `deploy.sh managed-finalize`

`workflow_dispatch` `managed-rollback` still calls the existing host `managed-rollback` phase (no CMS key).

Existing scripts do not copy the previous secret set; `install` still requires a fresh nine-file incoming directory, so the workflow compiles from Environment secrets into a mode-0700 dir under `$RUNNER_TEMP`.

## Environment secrets Pascal must create

Create GitHub Environment **`production`** (the job already references it). Secret *names* only; do not commit values. `DEPLOY_SSH_HOST` and `DEPLOY_SSH_USER` may be Environment variables instead of secrets.

| Environment secret / variable | Compiler / operator input |
| --- | --- |
| `DEPLOY_SSH_KEY` | SSH private key (PEM), written mode 0600 on the runner |
| `DEPLOY_SSH_HOST` | Production host IP or DNS (`StrictHostKeyChecking=yes`) |
| `DEPLOY_SSH_USER` | SSH user; optional, defaults to `root` |
| `DEPLOY_SSH_KNOWN_HOSTS` | `known_hosts` line(s) for `DEPLOY_SSH_HOST` |
| `GH_APP_ID` | `GITHUB_APP_ID` |
| `GH_WEBHOOK_SECRET` | `GITHUB_WEBHOOK_SECRET` |
| `GH_CLIENT_ID` | `GITHUB_CLIENT_ID` |
| `GH_CLIENT_SECRET` | `GITHUB_CLIENT_SECRET` |
| `GH_APP_PRIVATE_KEY` | PEM written to `GITHUB_PRIVATE_KEY_PATH` |
| `KEY_WRAPPING_PRIVATE_KEY` | PEM written to `KEY_WRAPPING_PRIVATE_KEY_PATH` |
| `KEY_WRAPPING_PUBLIC_KEY` | PEM written to `KEY_WRAPPING_PUBLIC_KEY_PATH` |
| `APP_BASE_URL` | `APP_BASE_URL` |
| `DATABASE_URL` | `DATABASE_URL` |
| `SESSION_SECRET` | `SESSION_SECRET` |
| `LOG_LEVEL` | `LOG_LEVEL` |
| `GENERATION_BASE_URL` | `GENERATION_BASE_URL` |
| `GENERATION_API_KEY` | `GENERATION_API_KEY` |
| `LEARNING_MODEL` | `LEARNING_MODEL` |
| `PRACTICE_MODEL` | `PRACTICE_MODEL` |
| `PROOF_QUESTION_MODEL` | `PROOF_QUESTION_MODEL` |
| `JUDGE_BASE_URL` | `JUDGE_BASE_URL` |
| `JUDGE_API_KEY` | `JUDGE_API_KEY` |
| `JUDGE_MODEL` | `JUDGE_MODEL` |
| `JUDGE_FALLBACK_MODEL` | `JUDGE_FALLBACK_MODEL` |
| `TRANSCRIPTION_BASE_URL` | `TRANSCRIPTION_BASE_URL` |
| `TRANSCRIPTION_API_KEY` | `TRANSCRIPTION_API_KEY` |
| `TRANSCRIPTION_MODEL` | `TRANSCRIPTION_MODEL` |
| `S3_CONTROL_ENDPOINT` | `S3_CONTROL_ENDPOINT` |
| `S3_PUBLIC_ENDPOINT` | `S3_PUBLIC_ENDPOINT` (also the image build-arg) |
| `S3_REGION` | `S3_REGION` |
| `S3_BUCKET` | `S3_BUCKET` |
| `S3_ACCESS_KEY_ID` | `S3_ACCESS_KEY_ID` |
| `S3_SECRET_ACCESS_KEY` | `S3_SECRET_ACCESS_KEY` |
| `WORKER_INTERNAL_SECRET` | `WORKER_INTERNAL_SECRET` |
| `PROVIDER_PAYLOAD_KEY_BASE64` | `PROVIDER_PAYLOAD_KEY_BASE64` |

GitHub forbids secret names starting with `GITHUB_`, so those compiler inputs are mapped through `GH_*`.

Hardcoded by the driver, not secrets: `NODE_ENV=production`, `DEMO_MODE=false`, `GITHUB_ADAPTER=octokit`, `GENERATION_PROVIDER=hetzner`, `MULTIMODAL_JUDGE_PROVIDER=hetzner`, `TRANSCRIPTION_PROVIDER=openrouter`, `EVIDENCE_STORAGE_PROVIDER=s3`, `KEY_WRAPPING_PROVIDER=local`, worker bind/ffmpeg paths, `/run/secrets/*` container paths. Provider cutover (Hetzner-only vs OpenRouter+fallback) is out of scope.

## Failure mode

- Missing Environment / secrets: the job fails closed before SSH.
- Dirty checkout, image/Trivy/SPDX identity mismatch, or non-`YYYYMMDDTHHMMSSZ` Release tag: fail closed before transfer.
- `StrictHostKeyChecking=yes`; compiler outputs and PEMs stay under `$RUNNER_TEMP` and are removed on EXIT.
- Public Actions logs get value-free status lines and receipts only; tracing (`set -x`) is refused.
- `migrate-start` / `managed-finalize` are not invoked, so a green stage does not move `current`.
- This is the managed path. If `current` is still bootstrap, `managed-prepare` fails; `initial-caddy-cutover` remains operator-held.
- A failed transfer/stage can leave `<id>.incoming` on the production host; re-run of the same ID needs operator cleanup. The workflow never uses `rsync --delete`.

## Verification

- [x] Unit or contract tests (`production-operations`, `production-deployment`)
- [ ] PostgreSQL integration tests when state or concurrency changed (none)
- [ ] Playwright coverage when a user flow changed (none)
- [ ] Threat model or provider data-flow update when a boundary changed (none; CMS boundary unchanged)
- [x] `pnpm audit:secrets` not required for this patch; no live values added
- [x] No credentials, private repository data or evidence artifacts included

Also green: `node --test` on the two contract files; Prettier on the touched JS/YAML/Markdown.

## Privacy and public output

none. Workflow comments list secret *names* only. Image SBOM/Trivy stay on the runner and in the host-side release bundle; they are not uploaded as Actions artifacts.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c38a4a9b-fffb-4665-90ec-4514fe558f54?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c38a4a9b-fffb-4665-90ec-4514fe558f54&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

