### PR TITLE
fix: invert public check CTAs and allow GitHub OAuth iss

### DIFF
--- a/apps/web/app/revisions/[revisionId]/page.tsx
+++ b/apps/web/app/revisions/[revisionId]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { z } from "zod";
 import { getWebRuntime } from "../../../lib/runtime";
+import { publicCheckCtas } from "./public-check-ctas";
 
 export const dynamic = "force-dynamic";
 
@@ -14,7 +15,7 @@ type PublicRevision = {
   status: "queued" | "in_progress" | "completed";
   conclusion: "action_required" | "success" | "neutral" | "cancelled" | null;
   public_summary: string;
-  has_contributor_flow: boolean;
+  has_attempt: boolean;
 };
 
 export default async function PublicRevisionPage({
@@ -33,13 +34,10 @@ export default async function PublicRevisionPage({
             pull_request.number AS pull_request_number,
             revision.head_sha, revision.is_current,
             check_run.status, check_run.conclusion, check_run.public_summary,
-            (EXISTS (
+            EXISTS (
               SELECT 1 FROM attempts attempt
               WHERE attempt.revision_id = revision.id
-            ) OR EXISTS (
-              SELECT 1 FROM semantic_generation_budgets semantic_budget
-              WHERE semantic_budget.revision_id = revision.id
-            )) AS has_contributor_flow
+            ) AS has_attempt
      FROM pull_request_revisions revision
      JOIN pull_requests pull_request ON pull_request.id = revision.pull_request_id
      JOIN repositories repository ON repository.id = pull_request.repository_id
@@ -50,6 +48,11 @@ export default async function PublicRevisionPage({
   );
   const revision = result.rows[0];
   if (!revision) notFound();
+  const ctas = publicCheckCtas({
+    isCurrent: revision.is_current,
+    conclusion: revision.conclusion,
+    hasAttempt: revision.has_attempt,
+  });
 
   return (
     <main className="shell flow-shell public-check-shell">
@@ -75,7 +78,7 @@ export default async function PublicRevisionPage({
         </div>
         <p>{revision.public_summary}</p>
         <div className="public-check-actions">
-          {revision.is_current && revision.has_contributor_flow ? (
+          {ctas.showContributor ? (
             <a
               className="button primary"
               href={`/revisions/${revisionId.data}/contribute`}
@@ -83,14 +86,16 @@ export default async function PublicRevisionPage({
               Continue as contributor
             </a>
           ) : null}
-          <a
-            className="button maintainer-button"
-            href={`/review?repositoryId=${encodeURIComponent(revision.repository_id)}`}
-          >
-            Protected maintainer view
-          </a>
+          {ctas.showMaintainer ? (
+            <a
+              className="button maintainer-button"
+              href={`/review?repositoryId=${encodeURIComponent(revision.repository_id)}`}
+            >
+              Protected maintainer view
+            </a>
+          ) : null}
         </div>
-        {revision.is_current && revision.has_contributor_flow ? (
+        {ctas.showContributor ? (
           <p className="public-check-guidance">
             After GitHub authorization, contributors choose between optional
             practice and the required live proof.

--- a/apps/web/app/revisions/[revisionId]/public-check-ctas.test.ts
+++ b/apps/web/app/revisions/[revisionId]/public-check-ctas.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { publicCheckCtas } from "./public-check-ctas";
+
+describe("public check CTAs", () => {
+  it("shows contributor, not maintainer, on a fresh current understanding check", () => {
+    expect(
+      publicCheckCtas({
+        isCurrent: true,
+        conclusion: null,
+        hasAttempt: false,
+      }),
+    ).toEqual({ showContributor: true, showMaintainer: false });
+  });
+
+  it("keeps contributor on a current understanding check after an attempt exists", () => {
+    expect(
+      publicCheckCtas({
+        isCurrent: true,
+        conclusion: "action_required",
+        hasAttempt: true,
+      }),
+    ).toEqual({ showContributor: true, showMaintainer: true });
+  });
+
+  it("hides contributor on historical heads and shows maintainer only when an attempt exists", () => {
+    expect(
+      publicCheckCtas({
+        isCurrent: false,
+        conclusion: "neutral",
+        hasAttempt: true,
+      }),
+    ).toEqual({ showContributor: false, showMaintainer: true });
+    expect(
+      publicCheckCtas({
+        isCurrent: false,
+        conclusion: null,
+        hasAttempt: false,
+      }),
+    ).toEqual({ showContributor: false, showMaintainer: false });
+  });
+
+  it("hides contributor once understanding is confirmed or the check is cancelled", () => {
+    expect(
+      publicCheckCtas({
+        isCurrent: true,
+        conclusion: "success",
+        hasAttempt: true,
+      }),
+    ).toEqual({ showContributor: false, showMaintainer: true });
+    expect(
+      publicCheckCtas({
+        isCurrent: true,
+        conclusion: "cancelled",
+        hasAttempt: false,
+      }),
+    ).toEqual({ showContributor: false, showMaintainer: false });
+  });
+});

--- a/apps/web/app/revisions/[revisionId]/public-check-ctas.ts
+++ b/apps/web/app/revisions/[revisionId]/public-check-ctas.ts
@@ -1,9 +1,5 @@
 export type PublicCheckConclusion =
-  | "action_required"
-  | "success"
-  | "neutral"
-  | "cancelled"
-  | null;
+  "action_required" | "success" | "neutral" | "cancelled" | null;
 
 export function publicCheckCtas(input: {
   isCurrent: boolean;

--- a/apps/web/app/revisions/[revisionId]/public-check-ctas.ts
+++ b/apps/web/app/revisions/[revisionId]/public-check-ctas.ts
@@ -1,0 +1,24 @@
+export type PublicCheckConclusion =
+  | "action_required"
+  | "success"
+  | "neutral"
+  | "cancelled"
+  | null;
+
+export function publicCheckCtas(input: {
+  isCurrent: boolean;
+  conclusion: PublicCheckConclusion;
+  hasAttempt: boolean;
+}): { showContributor: boolean; showMaintainer: boolean } {
+  return {
+    showContributor:
+      input.isCurrent && revisionRequiresUnderstanding(input.conclusion),
+    showMaintainer: input.hasAttempt,
+  };
+}
+
+function revisionRequiresUnderstanding(
+  conclusion: PublicCheckConclusion,
+): boolean {
+  return conclusion !== "success" && conclusion !== "cancelled";
+}

--- a/apps/web/lib/github-oauth-routes.test.ts
+++ b/apps/web/lib/github-oauth-routes.test.ts
@@ -164,6 +164,47 @@ describe("GitHub OAuth route handlers", () => {
     expect(await rejected.json()).toEqual({ error: "oauth_rejected" });
   });
 
+  it("accepts GitHub iss on the callback query allowlist and ignores its value", async () => {
+    const test = harness();
+    const response = await handleGithubOAuthCallback(
+      new Request(
+        "https://slopproof.example/api/auth/github/callback?code=one-use-code&state=one-use-state&iss=https%3A%2F%2Fgithub.com%2Flogin%2Foauth",
+        {
+          headers: {
+            cookie: `${GITHUB_OAUTH_FLOW_COOKIE}=v1.sealed-pkce-cookie`,
+          },
+        },
+      ),
+      test.resolve,
+    );
+    expect(response.status).toBe(303);
+    expect(test.oauth.callback).toHaveBeenCalledWith({
+      code: "one-use-code",
+      state: "one-use-state",
+      sealedCookie: "v1.sealed-pkce-cookie",
+    });
+  });
+
+  it("still rejects unknown callback query keys after allowing iss", async () => {
+    const test = harness();
+    const response = await handleGithubOAuthCallback(
+      new Request(
+        "https://slopproof.example/api/auth/github/callback?code=one-use-code&state=one-use-state&iss=https%3A%2F%2Fgithub.com%2Flogin%2Foauth&scope=repo",
+        {
+          headers: {
+            cookie: `${GITHUB_OAUTH_FLOW_COOKIE}=v1.sealed-pkce-cookie`,
+          },
+        },
+      ),
+      test.resolve,
+    );
+    expect(response.status).toBe(400);
+    expect(await response.text()).toContain(
+      "GitHub authorization did not finish",
+    );
+    expect(test.oauth.callback).not.toHaveBeenCalled();
+  });
+
   it("rotates session and sets only sealed Fresh-Auth material on callback", async () => {
     const test = harness();
     const response = await handleGithubOAuthCallback(

--- a/apps/web/lib/github-oauth-routes.ts
+++ b/apps/web/lib/github-oauth-routes.ts
@@ -89,11 +89,11 @@ export async function handleGithubOAuthCallback(
     if (url.searchParams.has("error")) {
       rejectUnknownQuery(
         url,
-        new Set(["error", "error_description", "error_uri", "state"]),
+        new Set(["error", "error_description", "error_uri", "state", "iss"]),
       );
       throw new GithubOAuthRejectedError();
     }
-    rejectUnknownQuery(url, new Set(["code", "state"]));
+    rejectUnknownQuery(url, new Set(["code", "state", "iss"]));
     const code = requiredSingleQueryValue(url, "code");
     const state = requiredSingleQueryValue(url, "state");
     const sealedCookie = requestCookieValue(request, GITHUB_OAUTH_FLOW_COOKIE);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Change

Rebased onto current `main` (`0286903`, squash-merged #11). Not stacked on #10, #12, or #13. Does not merge or deploy.

- Current understanding checks always show **Continue as contributor**. The old attempt/budget EXISTS gate is gone.
- **Protected maintainer view** only after at least one attempt exists. Historical heads never get the contributor CTA.
- OAuth callback allowlists GitHub’s `iss` and ignores its value. Cookie/state/PKCE checks are unchanged.

Fixes #14
Fixes #15

## Failure mode

Unknown callback query keys, duplicate params, missing flow cookie, state mismatch, and PKCE failure still 400. Public check still has no evidence. Tip includes OpenRouter MiMo from #11, so this does not roll generation back to Hetzner Kimi.

## Verification

- [x] Unit tests (CTA matrix; callback `code`+`state`+`iss` allowlist)
- [ ] PostgreSQL integration tests (none)
- [x] Playwright: seeded check still has both CTAs because an attempt exists
- [ ] Threat model (none)
- [x] `pnpm verify` green after rebase onto `0286903`
- [x] No credentials, private repository data or evidence artifacts included

## Privacy and public output

none

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cda4059a-060d-4136-bfd1-b8d5d4dc4231?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cda4059a-060d-4136-bfd1-b8d5d4dc4231&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

