### PR TITLE
fix: start learning deadline after proof content exists

### DIFF
--- a/apps/worker/src/semantic-generation-contracts.ts
+++ b/apps/worker/src/semantic-generation-contracts.ts
@@ -160,7 +160,7 @@ export interface SemanticGenerationRepository {
       | JobPayload<"semantic.generate-learning">
       | JobPayload<"semantic.generate-practice-feedback">
       | JobPayload<"semantic.generate-proof-questions">,
-  ): Promise<SemanticRunContext | "stale">;
+  ): Promise<SemanticRunContext | "stale" | "proof_pending">;
   loadPracticeQuestionAndAnswer(
     run: SemanticRunContext,
     payload: JobPayload<"semantic.generate-practice-feedback">,

--- a/apps/worker/src/semantic-generation-jobs.test.ts
+++ b/apps/worker/src/semantic-generation-jobs.test.ts
@@ -1,0 +1,148 @@
+import type { JobPayload } from "@slopproof/db";
+import { describe, expect, it, vi } from "vitest";
+import type { GenerationContextV1 } from "@slopproof/analysis";
+import { createSemanticGenerationJobHandlers } from "./semantic-generation-jobs";
+import type {
+  SemanticGenerationRepository,
+  SemanticRunContext,
+} from "./semantic-generation-contracts";
+import type { SemanticGenerationService } from "./semantic-generation";
+
+describe("semantic generation job handlers", () => {
+  it("does not start Learning generation while Proof is pending", async () => {
+    const generateLearningBundle = vi.fn(async () => {
+      throw new Error("Learning must not generate while Proof is pending");
+    });
+    const loadFrozenProofContent = vi.fn(async () => {
+      throw new Error("Learning must not load Proof while still pending");
+    });
+    const handlers = createSemanticGenerationJobHandlers({
+      repository: repositoryStub({
+        reserveRun: vi.fn(async () => "proof_pending" as const),
+        loadFrozenProofContent,
+      }),
+      service: serviceStub({ generateLearningBundle }),
+    });
+
+    await expect(
+      handlers["semantic.generate-learning"](learningPayload()),
+    ).resolves.toEqual({ outcome: "proof_pending" });
+    expect(loadFrozenProofContent).not.toHaveBeenCalled();
+    expect(generateLearningBundle).not.toHaveBeenCalled();
+  });
+
+  it("gives Learning the reserved generate window once Proof content exists", async () => {
+    const createdAt = new Date("2026-08-19T15:46:12.000Z");
+    const deadlineAt = new Date("2026-08-19T15:54:12.000Z");
+    const generateLearningBundle = vi.fn(async (request: unknown) => {
+      void request;
+      return {
+        artifact: { id: "82000000-0000-4000-8000-000000000021" },
+        providerMetadata: {},
+        providerFailure: null,
+        degraded: false,
+      } as Awaited<
+        ReturnType<SemanticGenerationService["generateLearningBundle"]>
+      >;
+    });
+    const persistLearning = vi.fn(async () => "created" as const);
+    const handlers = createSemanticGenerationJobHandlers({
+      repository: repositoryStub({
+        reserveRun: vi.fn(async () =>
+          runFixture({
+            createdAt,
+            deadlineAt,
+          }),
+        ),
+        loadFrozenProofContent: vi.fn(async () => [
+          "Explain the exact cache-miss return change.",
+        ]),
+        persistLearning,
+      }),
+      service: serviceStub({ generateLearningBundle }),
+    });
+
+    await expect(
+      handlers["semantic.generate-learning"](learningPayload()),
+    ).resolves.toEqual({
+      outcome: "created",
+      artifactId: "82000000-0000-4000-8000-000000000021",
+      degraded: false,
+    });
+    expect(generateLearningBundle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        artifactCreatedAt: createdAt,
+        deadlineAt,
+        forbiddenProofContent: ["Explain the exact cache-miss return change."],
+      }),
+    );
+    expect(deadlineAt.getTime() - createdAt.getTime()).toBe(8 * 60_000);
+  });
+});
+
+function learningPayload(): JobPayload<"semantic.generate-learning"> {
+  return {
+    schemaVersion: "1",
+    idempotencyKey: "semantic.learning.v3:82000000-0000-4000-8000-000000000003",
+    artifactKind: "learning_bundle_v1",
+    revisionId: "82000000-0000-4000-8000-000000000002",
+    generationContextId: "82000000-0000-4000-8000-000000000003",
+    expectedHeadSha: "a".repeat(40),
+  };
+}
+
+function runFixture(input: {
+  createdAt: Date;
+  deadlineAt: Date;
+}): SemanticRunContext {
+  return {
+    runId: "82000000-0000-4000-8000-000000000099",
+    idempotencyKey: learningPayload().idempotencyKey,
+    repositoryId: "82000000-0000-4000-8000-000000000001",
+    revisionId: learningPayload().revisionId,
+    generationContextId: learningPayload().generationContextId,
+    authorId: "author-1",
+    repositoryPolicyId: "82000000-0000-4000-8000-000000000004",
+    generationContext: {
+      headSha: learningPayload().expectedHeadSha,
+    } as GenerationContextV1,
+    artifactSeed: "9".repeat(64),
+    questionCount: 3,
+    createdAt: input.createdAt,
+    deadlineAt: input.deadlineAt,
+    deleteAfter: new Date("2026-08-20T15:46:12.000Z"),
+    completedArtifactId: null,
+  };
+}
+
+function repositoryStub(
+  overrides: Partial<SemanticGenerationRepository>,
+): SemanticGenerationRepository {
+  return {
+    scheduleRevisionSemanticGeneration: vi.fn(),
+    reserveRun: vi.fn(),
+    loadPracticeQuestionAndAnswer: vi.fn(),
+    loadFrozenProofContent: vi.fn(),
+    persistLearning: vi.fn(),
+    persistPracticeFeedback: vi.fn(),
+    persistProofPlanAndCreateAttempt: vi.fn(),
+    replayCompletedProof: vi.fn(),
+    expirePrivate: vi.fn(),
+    startPracticeSession: vi.fn(),
+    submitPracticeAnswer: vi.fn(),
+    readPracticeView: vi.fn(),
+    sweepDueSemanticPrivate: vi.fn(),
+    ...overrides,
+  } as SemanticGenerationRepository;
+}
+
+function serviceStub(
+  overrides: Partial<SemanticGenerationService>,
+): SemanticGenerationService {
+  return {
+    generateLearningBundle: vi.fn(),
+    generatePracticeFeedback: vi.fn(),
+    generateProofQuestionPlan: vi.fn(),
+    ...overrides,
+  } as SemanticGenerationService;
+}

--- a/apps/worker/src/semantic-generation-jobs.ts
+++ b/apps/worker/src/semantic-generation-jobs.ts
@@ -20,6 +20,7 @@ export function createSemanticGenerationJobHandlers(
         payload,
       );
       if (run === "stale") return { outcome: "stale" };
+      if (run === "proof_pending") return { outcome: "proof_pending" };
       if (run.completedArtifactId !== null) return { outcome: "replayed" };
       const forbiddenProofContent =
         await dependencies.repository.loadFrozenProofContent(run);
@@ -51,6 +52,7 @@ export function createSemanticGenerationJobHandlers(
         payload,
       );
       if (run === "stale") return { outcome: "stale" };
+      if (run === "proof_pending") return { outcome: "proof_pending" };
       if (run.completedArtifactId !== null) return { outcome: "replayed" };
       const privateInput =
         await dependencies.repository.loadPracticeQuestionAndAnswer(
@@ -93,6 +95,11 @@ export function createSemanticGenerationJobHandlers(
         payload,
       );
       if (run === "stale") return { outcome: "stale" };
+      if (run === "proof_pending") {
+        throw new Error(
+          "Proof generation does not wait on frozen Proof content.",
+        );
+      }
       if (run.completedArtifactId !== null) {
         return dependencies.repository.replayCompletedProof(run);
       }

--- a/apps/worker/src/semantic-generation-repository.test.ts
+++ b/apps/worker/src/semantic-generation-repository.test.ts
@@ -1,3 +1,9 @@
+import {
+  analyzePullRequestPatch,
+  boundedRevisionSourcePatch,
+  buildBoundedRevisionSourceV1,
+  buildGenerationContextV1,
+} from "@slopproof/analysis";
 import type { DatabaseConnection, JobPayload } from "@slopproof/db";
 import { describe, expect, it, vi } from "vitest";
 import type { PoolClient } from "pg";
@@ -330,6 +336,46 @@ describe("Gate 4 persistence boundary", () => {
       expect.anything(),
     );
   });
+
+  it("does not insert a Learning run while frozen Proof content is pending", async () => {
+    const query = reserveRunQueryFixture({ proofReady: false });
+    const repository = repositoryFixture(query, schedulerFixture());
+
+    await expect(
+      repository.reserveRun("semantic.generate-learning", learningPayload()),
+    ).resolves.toBe("proof_pending");
+    expect(
+      query.mock.calls.some((call) =>
+        String(call.at(0) ?? "").includes(
+          "INSERT INTO semantic_generation_runs",
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it("arms the full Learning deadline only after frozen Proof content exists", async () => {
+    const now = new Date("2026-08-19T15:46:12.000Z");
+    const query = reserveRunQueryFixture({ proofReady: true, now });
+    const repository = repositoryFixture(query, schedulerFixture());
+
+    const reserved = await repository.reserveRun(
+      "semantic.generate-learning",
+      learningPayload(),
+    );
+
+    expect(reserved).not.toBe("stale");
+    expect(reserved).not.toBe("proof_pending");
+    if (reserved === "stale" || reserved === "proof_pending") return;
+    expect(reserved.createdAt).toEqual(now);
+    expect(reserved.deadlineAt).toEqual(new Date(now.getTime() + 8 * 60_000));
+    expect(reserved.completedArtifactId).toBeNull();
+    const insert = query.mock.calls.find((call) =>
+      String(call.at(0) ?? "").includes("INSERT INTO semantic_generation_runs"),
+    );
+    expect(insert?.at(1)).toEqual(
+      expect.arrayContaining([now, new Date(now.getTime() + 8 * 60_000)]),
+    );
+  });
 });
 
 const IDS = {
@@ -380,4 +426,151 @@ function repositoryFixture(
   );
 }
 
-void (null as unknown as JobPayload<"semantic.generate-learning">);
+function learningPayload(): JobPayload<"semantic.generate-learning"> {
+  return {
+    schemaVersion: "1",
+    idempotencyKey: `semantic.learning.v3:${IDS.context}`,
+    artifactKind: "learning_bundle_v1",
+    revisionId: IDS.revision,
+    generationContextId: IDS.context,
+    expectedHeadSha: HEAD,
+  };
+}
+
+function reserveRunQueryFixture(input: {
+  proofReady: boolean;
+  now?: Date;
+}): ReturnType<typeof vi.fn> {
+  const now = input.now ?? new Date("2026-08-19T15:41:35.000Z");
+  const context = generationContextFixture();
+  let inserted: unknown[] | undefined;
+  return vi.fn(async (statement: string, values: unknown[] = []) => {
+    if (
+      statement === "BEGIN" ||
+      statement === "COMMIT" ||
+      statement === "ROLLBACK" ||
+      statement.includes("pg_advisory_xact_lock")
+    ) {
+      return { rows: [], rowCount: 0 };
+    }
+    if (statement.includes("FROM generation_contexts context")) {
+      return {
+        rowCount: 1,
+        rows: [
+          {
+            repository_id: IDS.repository,
+            revision_id: IDS.revision,
+            generation_context_id: IDS.context,
+            author_id: "author-1",
+            repository_policy_id: IDS.policy,
+            head_sha: HEAD,
+            context_hash: context.contextHash,
+            context,
+            question_budget: 3,
+            is_current: true,
+            pull_request_state: "open",
+          },
+        ],
+      };
+    }
+    if (statement.includes("SELECT clock_timestamp() AS now")) {
+      return { rows: [{ now }], rowCount: 1 };
+    }
+    if (statement.includes("FROM proof_plans plan")) {
+      return input.proofReady
+        ? {
+            rowCount: 1,
+            rows: [
+              {
+                semantic_plan: null,
+                legacy_questions: [
+                  {
+                    prompt: "Explain the exact cache-miss return change.",
+                    rubric: {
+                      requiredPoints: [
+                        "Name the previous empty-string fallback.",
+                        "Name the new null miss return.",
+                      ],
+                    },
+                  },
+                ],
+              },
+            ],
+          }
+        : { rows: [], rowCount: 0 };
+    }
+    if (statement.includes("INSERT INTO semantic_generation_runs")) {
+      inserted = values;
+      return { rows: [], rowCount: 1 };
+    }
+    if (statement.includes("FROM semantic_generation_runs")) {
+      if (inserted === undefined) return { rows: [], rowCount: 0 };
+      return {
+        rowCount: 1,
+        rows: [
+          {
+            id: "82000000-0000-4000-8000-000000000099",
+            idempotency_key: inserted[0],
+            purpose: inserted[1],
+            repository_id: inserted[2],
+            revision_id: inserted[3],
+            generation_context_id: inserted[4],
+            practice_session_id: inserted[5],
+            practice_question_id: inserted[6],
+            practice_answer_id: inserted[7],
+            artifact_seed: inserted[8],
+            question_count: inserted[9],
+            created_at: inserted[10],
+            deadline_at: inserted[11],
+            delete_after: inserted[12],
+            artifact_id: null,
+          },
+        ],
+      };
+    }
+    return { rows: [], rowCount: 0 };
+  });
+}
+
+function generationContextFixture() {
+  const bounded = buildBoundedRevisionSourceV1({
+    githubPullRequestId: "8201",
+    number: 8,
+    state: "open",
+    draft: false,
+    title: "Return an explicit cache miss",
+    body: "Replace the empty-string fallback with null.",
+    authorId: "8205",
+    authorLogin: "contributor",
+    headSha: HEAD,
+    baseSha: "b".repeat(40),
+    changedFiles: 1,
+    isFork: false,
+    files: [
+      {
+        sha: "c".repeat(40),
+        gitKind: "blob" as const,
+        filename: "src/cache.ts",
+        previousFilename: null,
+        status: "modified" as const,
+        additions: 1,
+        deletions: 1,
+        changes: 2,
+        patch:
+          "@@ -1,1 +1,1 @@\n-return cache.get(key) ?? '';\n+return cache.get(key) ?? null;",
+      },
+    ],
+    limitsHit: {
+      files: false,
+      patchBytes: false,
+      patchUnavailable: false,
+    },
+  });
+  const analysis = analyzePullRequestPatch(boundedRevisionSourcePatch(bounded));
+  return buildGenerationContextV1({
+    revisionId: IDS.revision,
+    analysisSnapshotId: IDS.context,
+    boundedSource: bounded,
+    analysis,
+  });
+}

--- a/apps/worker/src/semantic-generation-repository.ts
+++ b/apps/worker/src/semantic-generation-repository.ts
@@ -47,7 +47,7 @@ const MAX_PRACTICE_ANSWER_BYTES = 4_000;
 const GENERATION_DEADLINE_MS = 8 * 60_000;
 const PRIVATE_RETENTION_MS = 24 * 60 * 60_000;
 const ATTEMPT_LIFETIME_MS = 8 * 60 * 60_000;
-const LEARNING_GENERATION_IDEMPOTENCY_VERSION = "v2";
+const LEARNING_GENERATION_IDEMPOTENCY_VERSION = "v3";
 
 type RunLookupRow = {
   repository_id: string;
@@ -201,85 +201,12 @@ export class PostgresSemanticGenerationRepository implements SemanticGenerationR
   async loadFrozenProofContent(
     run: SemanticRunContext,
   ): Promise<ForbiddenProofContentV1 | "pending"> {
-    const result = await this.database.pool.query<{
-      semantic_plan: unknown | null;
-      legacy_questions: unknown;
-    }>(
-      `SELECT semantic_plan.plan AS semantic_plan,
-              jsonb_agg(
-                jsonb_build_object(
-                  'prompt', question.prompt,
-                  'rubric', question.rubric
-                ) ORDER BY question.ordinal
-              ) AS legacy_questions
-         FROM proof_plans plan
-         JOIN semantic_generation_budgets budget
-           ON budget.generation_context_id = plan.generation_context_id
-          AND budget.revision_id = plan.revision_id
-         JOIN proof_questions question ON question.proof_plan_id = plan.id
-         LEFT JOIN semantic_proof_plans_v2 semantic_plan
-           ON semantic_plan.id = plan.id
-        WHERE plan.revision_id = $1
-          AND plan.generation_context_id = $2
-          AND plan.status = 'ready'
-          AND plan.question_budget = budget.question_budget
-          AND EXISTS (
-            SELECT 1 FROM attempts attempt
-             WHERE attempt.proof_plan_id = plan.id
-               AND attempt.revision_id = $1
-               AND attempt.author_id = $3
-               AND attempt.head_sha = $4
-          )
-        GROUP BY plan.id, plan.created_at, semantic_plan.plan
-       HAVING count(question.id)::int = plan.question_budget
-        ORDER BY plan.created_at DESC, plan.id DESC
-        LIMIT 1`,
-      [
-        run.revisionId,
-        run.generationContextId,
-        run.authorId,
-        run.generationContext.headSha,
-      ],
-    );
-    const row = result.rows[0];
-    if (row === undefined) return "pending";
-    if (row.semantic_plan !== null) {
-      const plan = hydrateSemanticArtifact(
-        row.semantic_plan,
-        ProofQuestionPlanV2Schema,
-      );
-      if (plan === null) {
-        throw new Error("Frozen semantic Proof plan is invalid.");
-      }
-      return ForbiddenProofContentV1Schema.parse(
-        proofQuestionsContentV1(plan.questions),
-      );
-    }
-    const questions = z
-      .array(
-        z
-          .object({
-            prompt: z.string().trim().min(1).max(2_000),
-            rubric: z
-              .object({
-                requiredPoints: z
-                  .array(z.string().trim().min(1).max(300))
-                  .min(1)
-                  .max(8),
-              })
-              .passthrough(),
-          })
-          .strict(),
-      )
-      .min(1)
-      .max(5)
-      .parse(row.legacy_questions);
-    return ForbiddenProofContentV1Schema.parse(
-      questions.flatMap((question) => [
-        question.prompt,
-        ...question.rubric.requiredPoints,
-      ]),
-    );
+    return readFrozenProofContent(this.database.pool, {
+      revisionId: run.revisionId,
+      generationContextId: run.generationContextId,
+      authorId: run.authorId,
+      headSha: run.generationContext.headSha,
+    });
   }
 
   async reserveRun(
@@ -291,7 +218,7 @@ export class PostgresSemanticGenerationRepository implements SemanticGenerationR
       | JobPayload<"semantic.generate-learning">
       | JobPayload<"semantic.generate-practice-feedback">
       | JobPayload<"semantic.generate-proof-questions">,
-  ): Promise<SemanticRunContext | "stale"> {
+  ): Promise<SemanticRunContext | "stale" | "proof_pending"> {
     const purpose = purposeForJob(name);
     const client = await this.database.pool.connect();
     try {
@@ -377,30 +304,6 @@ export class PostgresSemanticGenerationRepository implements SemanticGenerationR
           payload.idempotencyKey,
         ].join(":"),
       );
-      await client.query(
-        `INSERT INTO semantic_generation_runs
-           (idempotency_key, purpose, repository_id, revision_id,
-            generation_context_id, practice_session_id, practice_question_id,
-            practice_answer_id, artifact_seed, question_count, created_at,
-            deadline_at, delete_after)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
-         ON CONFLICT (idempotency_key) DO NOTHING`,
-        [
-          payload.idempotencyKey,
-          purpose,
-          lookup.repository_id,
-          lookup.revision_id,
-          lookup.generation_context_id,
-          practice?.practiceSessionId ?? null,
-          practice?.practiceQuestionId ?? null,
-          practice?.practiceAnswerId ?? null,
-          artifactSeed,
-          questionCount,
-          now,
-          new Date(now.getTime() + GENERATION_DEADLINE_MS),
-          deleteAfter,
-        ],
-      );
       const persisted = await client.query<RunRow>(
         `SELECT id, idempotency_key, purpose, repository_id, revision_id,
                 generation_context_id, practice_session_id,
@@ -412,7 +315,57 @@ export class PostgresSemanticGenerationRepository implements SemanticGenerationR
           FOR SHARE`,
         [payload.idempotencyKey],
       );
-      const run = persisted.rows[0];
+      let run = persisted.rows[0];
+      if (run === undefined) {
+        if (purposeRequiresFrozenProof(purpose)) {
+          const forbiddenProofContent = await readFrozenProofContent(client, {
+            revisionId: lookup.revision_id,
+            generationContextId: lookup.generation_context_id,
+            authorId: lookup.author_id,
+            headSha: lookup.head_sha,
+          });
+          if (forbiddenProofContent === "pending") {
+            await client.query("ROLLBACK");
+            return "proof_pending";
+          }
+        }
+        await client.query(
+          `INSERT INTO semantic_generation_runs
+             (idempotency_key, purpose, repository_id, revision_id,
+              generation_context_id, practice_session_id, practice_question_id,
+              practice_answer_id, artifact_seed, question_count, created_at,
+              deadline_at, delete_after)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+           ON CONFLICT (idempotency_key) DO NOTHING`,
+          [
+            payload.idempotencyKey,
+            purpose,
+            lookup.repository_id,
+            lookup.revision_id,
+            lookup.generation_context_id,
+            practice?.practiceSessionId ?? null,
+            practice?.practiceQuestionId ?? null,
+            practice?.practiceAnswerId ?? null,
+            artifactSeed,
+            questionCount,
+            now,
+            new Date(now.getTime() + GENERATION_DEADLINE_MS),
+            deleteAfter,
+          ],
+        );
+        const inserted = await client.query<RunRow>(
+          `SELECT id, idempotency_key, purpose, repository_id, revision_id,
+                  generation_context_id, practice_session_id,
+                  practice_question_id, practice_answer_id,
+                  artifact_seed, question_count,
+                  created_at, deadline_at, delete_after, artifact_id
+             FROM semantic_generation_runs
+            WHERE idempotency_key = $1
+            FOR SHARE`,
+          [payload.idempotencyKey],
+        );
+        run = inserted.rows[0];
+      }
       if (
         run === undefined ||
         run.repository_id !== lookup.repository_id ||
@@ -1976,6 +1929,102 @@ function purposeForJob(
     : name === "semantic.generate-practice-feedback"
       ? ("practice_feedback" as const)
       : ("proof_questions" as const);
+}
+
+function purposeRequiresFrozenProof(
+  purpose: ReturnType<typeof purposeForJob>,
+): boolean {
+  return purpose !== "proof_questions";
+}
+
+async function readFrozenProofContent(
+  queryable: Pick<PoolClient, "query">,
+  input: {
+    revisionId: string;
+    generationContextId: string;
+    authorId: string;
+    headSha: string;
+  },
+): Promise<ForbiddenProofContentV1 | "pending"> {
+  const result = await queryable.query<{
+    semantic_plan: unknown | null;
+    legacy_questions: unknown;
+  }>(
+    `SELECT semantic_plan.plan AS semantic_plan,
+            jsonb_agg(
+              jsonb_build_object(
+                'prompt', question.prompt,
+                'rubric', question.rubric
+              ) ORDER BY question.ordinal
+            ) AS legacy_questions
+       FROM proof_plans plan
+       JOIN semantic_generation_budgets budget
+         ON budget.generation_context_id = plan.generation_context_id
+        AND budget.revision_id = plan.revision_id
+       JOIN proof_questions question ON question.proof_plan_id = plan.id
+       LEFT JOIN semantic_proof_plans_v2 semantic_plan
+         ON semantic_plan.id = plan.id
+      WHERE plan.revision_id = $1
+        AND plan.generation_context_id = $2
+        AND plan.status = 'ready'
+        AND plan.question_budget = budget.question_budget
+        AND EXISTS (
+          SELECT 1 FROM attempts attempt
+           WHERE attempt.proof_plan_id = plan.id
+             AND attempt.revision_id = $1
+             AND attempt.author_id = $3
+             AND attempt.head_sha = $4
+        )
+      GROUP BY plan.id, plan.created_at, semantic_plan.plan
+     HAVING count(question.id)::int = plan.question_budget
+      ORDER BY plan.created_at DESC, plan.id DESC
+      LIMIT 1`,
+    [
+      input.revisionId,
+      input.generationContextId,
+      input.authorId,
+      input.headSha,
+    ],
+  );
+  const row = result.rows[0];
+  if (row === undefined) return "pending";
+  if (row.semantic_plan !== null) {
+    const plan = hydrateSemanticArtifact(
+      row.semantic_plan,
+      ProofQuestionPlanV2Schema,
+    );
+    if (plan === null) {
+      throw new Error("Frozen semantic Proof plan is invalid.");
+    }
+    return ForbiddenProofContentV1Schema.parse(
+      proofQuestionsContentV1(plan.questions),
+    );
+  }
+  const questions = z
+    .array(
+      z
+        .object({
+          prompt: z.string().trim().min(1).max(2_000),
+          rubric: z
+            .object({
+              requiredPoints: z
+                .array(z.string().trim().min(1).max(300))
+                .min(1)
+                .max(8),
+            })
+            .passthrough(),
+        })
+        .strict(),
+    )
+    .min(1)
+    .max(5)
+    .parse(row.legacy_questions);
+  return ForbiddenProofContentV1Schema.parse(
+    questions.flatMap((question) => [
+      question.prompt,
+      ...question.rubric.requiredPoints,
+    ]),
+  );
 }
 
 function learningJob(input: {

--- a/tests/integration/semantic-generation-persistence.integration.test.ts
+++ b/tests/integration/semantic-generation-persistence.integration.test.ts
@@ -113,6 +113,57 @@ databaseDescribe("Gate 4 semantic persistence and served Proof V2", () => {
     }
   });
 
+  it("does not consume the Learning generate deadline while waiting for Proof", async () => {
+    await expect(
+      handlers["semantic.generate-learning"](learningJob(generationContextId)),
+    ).resolves.toEqual({ outcome: "proof_pending" });
+    await expect(
+      database.pool.query<{ count: number }>(
+        `SELECT count(*)::int AS count
+           FROM semantic_generation_runs
+          WHERE purpose = 'learning_material'`,
+      ),
+    ).resolves.toMatchObject({ rows: [{ count: 0 }] });
+
+    const beforeEligible = await database.pool.query<{ now: Date }>(
+      "SELECT clock_timestamp() AS now",
+    );
+    const proof = await handlers["semantic.generate-proof-questions"](
+      proofJob(generationContextId),
+    );
+    expect(proof).toMatchObject({ outcome: "created" });
+
+    await expect(
+      generatedLearningHandlers(repository, generationContext)[
+        "semantic.generate-learning"
+      ](learningJob(generationContextId)),
+    ).resolves.toMatchObject({ outcome: "created", degraded: false });
+
+    const learningRun = await database.pool.query<{
+      created_at: Date;
+      window_seconds: number;
+      invocation_count: number;
+      outcome: string;
+    }>(
+      `SELECT run.created_at,
+              extract(epoch FROM (run.deadline_at - run.created_at))::int
+                AS window_seconds,
+              invocation.invocation_count,
+              invocation.outcome
+         FROM semantic_generation_runs run
+         JOIN semantic_provider_invocations invocation
+           ON invocation.run_id = run.id
+        WHERE run.purpose = 'learning_material'`,
+    );
+    expect(learningRun.rows).toHaveLength(1);
+    expect(learningRun.rows[0]?.window_seconds).toBe(480);
+    expect(learningRun.rows[0]?.invocation_count).toBe(1);
+    expect(learningRun.rows[0]?.outcome).toBe("generated");
+    expect(learningRun.rows[0]!.created_at.getTime()).toBeGreaterThanOrEqual(
+      beforeEligible.rows[0]!.now.getTime(),
+    );
+  });
+
   it("stores degraded Learning privately without serving it as Practice", async () => {
     await expect(
       handlers["semantic.generate-learning"](learningJob(generationContextId)),
@@ -863,7 +914,7 @@ const AUTHOR = "8305";
 function learningJob(generationContextId: string) {
   return {
     schemaVersion: "1" as const,
-    idempotencyKey: `semantic.learning.v2:${generationContextId}`,
+    idempotencyKey: `semantic.learning.v3:${generationContextId}`,
     artifactKind: "learning_bundle_v1" as const,
     revisionId: IDS.revision,
     generationContextId,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Change

Learning and practice-feedback generation no longer arm the 8-minute provider deadline when the job is first reserved and `forbiddenProofContent` is still `proof_pending`.

`reserveRun` now:

- returns `proof_pending` without inserting a `semantic_generation_runs` row while frozen Proof content is missing
- inserts the run and starts `deadline_at = now + 480s` only at the first eligible generate

`invokeWithOneRepair` is unchanged. It still honors the reserved window and still falls back instead of serving templates as a real patch reading.

Learning idempotency moves from `v2` to `v3` so heads that already completed a burned-wait fallback (including revision `6642c9e1-ed34-49b3-a31f-c3000343c037`) get one new attempt with a full window. A second degraded attempt still withholds practice (`generation_failed`).

Does not merge or deploy.

## Failure mode

- Proof still missing: learning returns `proof_pending` and does not persist a run or a fallback bundle.
- Proof exists: learning has a bounded 8-minute generate window. Timeout / invalid output after one repair still fail closed and are not shown as Practice.
- Already-completed `v3` fallbacks stay terminal. The version bump is one new attempt, not an unbounded retry.

## Verification

- [x] Unit or contract tests (reserve does not insert while pending; full 480s window after Proof exists; handler does not call the model on `proof_pending`)
- [x] PostgreSQL integration tests when state or concurrency changed (`pnpm test:integration`: 107 passed, including the wait-does-not-consume-deadline case)
- [ ] Playwright coverage when a user flow changed (none)
- [ ] Threat model or provider data-flow update when a boundary changed (none)
- [x] `pnpm audit:secrets`
- [x] No credentials, private repository data or evidence artifacts included

Also green: `pnpm lint`, `pnpm typecheck`, `pnpm test` (738).

## Privacy and public output

none

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cbda17bc-1810-4028-be86-69a233833086?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cbda17bc-1810-4028-be86-69a233833086&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

