### PR TITLE
fix: keep understanding check pending until maintainer decision

### DIFF
--- a/apps/worker/src/provider-pipeline-repository.ts
+++ b/apps/worker/src/provider-pipeline-repository.ts
@@ -4,6 +4,10 @@ import {
   type DatabaseConnection,
   type JobPayload,
 } from "@slopproof/db";
+import {
+  REVIEW_REQUIRED_GITHUB_CHECK,
+  TECHNICAL_RETRY_GITHUB_CHECK,
+} from "@slopproof/github";
 import { FinalizeRecordingSchema } from "@slopproof/media";
 import type { RepositoryPolicyV1 } from "@slopproof/policy";
 import type {
@@ -1189,8 +1193,7 @@ export class PostgresProviderPipelineRepository implements ProviderPipelineRepos
       await this.checkIntents.write(client, {
         revisionId: row.revision_id,
         headSha: row.head_sha,
-        status: "in_progress",
-        conclusion: null,
+        ...REVIEW_REQUIRED_GITHUB_CHECK,
         summary: `maintainer review required for head ${row.head_sha}`,
         reason: "review_required",
         idempotencyKey: input.idempotencyKey,
@@ -1282,8 +1285,7 @@ export class PostgresProviderPipelineRepository implements ProviderPipelineRepos
       await this.checkIntents.write(client, {
         revisionId: row.revision_id,
         headSha: row.head_sha,
-        status: "completed",
-        conclusion: "neutral",
+        ...TECHNICAL_RETRY_GITHUB_CHECK,
         summary: `technical retry required for head ${row.head_sha}`,
         reason: "technical_retry",
         idempotencyKey: input.idempotencyKey,

--- a/packages/db/src/github-check-intent.test.ts
+++ b/packages/db/src/github-check-intent.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseGithubCheckIntent,
+  type GithubCheckIntent,
+} from "./github-production";
+
+const baseIntent: GithubCheckIntent = {
+  revisionId: "10000000-0000-4000-8000-000000000001",
+  expectedHeadSha: "a".repeat(40),
+  idempotencyKey: "check:intent:review-required",
+  reason: "review_required",
+  name: "SlopProof / understanding required",
+  status: "in_progress",
+  conclusion: null,
+  publicSummary: "maintainer review required for head",
+  detailsUrl:
+    "https://slopproof.test/revisions/10000000-0000-4000-8000-000000000001",
+};
+
+describe("GitHub check intent persist contract", () => {
+  it("accepts review_required only as in_progress with no conclusion", () => {
+    expect(parseGithubCheckIntent(baseIntent)).toMatchObject({
+      reason: "review_required",
+      status: "in_progress",
+      conclusion: null,
+    });
+  });
+
+  it("rejects review_required completed+neutral, which would satisfy a required check", () => {
+    expect(() =>
+      parseGithubCheckIntent({
+        ...baseIntent,
+        status: "completed",
+        conclusion: "neutral",
+      }),
+    ).toThrow(/review_required checks must stay in_progress/);
+  });
+
+  it("keeps completed+neutral only for technical_retry", () => {
+    expect(
+      parseGithubCheckIntent({
+        ...baseIntent,
+        idempotencyKey: "check:intent:technical-retry",
+        reason: "technical_retry",
+        status: "completed",
+        conclusion: "neutral",
+        publicSummary: "technical retry required for head",
+      }),
+    ).toMatchObject({
+      reason: "technical_retry",
+      status: "completed",
+      conclusion: "neutral",
+    });
+  });
+});

--- a/packages/db/src/github-production.ts
+++ b/packages/db/src/github-production.ts
@@ -218,6 +218,17 @@ const GithubCheckIntentSchema = z
         message: "non-completed checks cannot have a conclusion",
       });
     }
+    if (
+      intent.reason === "review_required" &&
+      (intent.status !== "in_progress" || intent.conclusion !== null)
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["status"],
+        message:
+          "review_required checks must stay in_progress without a conclusion",
+      });
+    }
   });
 
 export type GithubOauthFlow = {
@@ -231,6 +242,12 @@ export type GithubOauthFlow = {
 
 export type GithubCheckIntent = z.input<typeof GithubCheckIntentSchema>;
 export type { GithubRevisionSource };
+
+export function parseGithubCheckIntent(
+  rawInput: GithubCheckIntent,
+): z.output<typeof GithubCheckIntentSchema> {
+  return GithubCheckIntentSchema.parse(rawInput);
+}
 
 export type PersistedGithubRevisionSource = {
   revisionId: string;
@@ -493,7 +510,7 @@ export async function persistGithubCheckIntentInTransaction(
   outbox: GithubCheckOutbox,
   rawInput: GithubCheckIntent,
 ): Promise<{ checkRunId: string; replay: boolean; queueJobId: string | null }> {
-  const input = GithubCheckIntentSchema.parse(rawInput);
+  const input = parseGithubCheckIntent(rawInput);
   const intentHash = hashCheckIntent(input);
   const revision = await client.query<{
     head_sha: string;

--- a/packages/github/src/check-gate.test.ts
+++ b/packages/github/src/check-gate.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  REVIEW_REQUIRED_GITHUB_CHECK,
+  TECHNICAL_RETRY_GITHUB_CHECK,
+  requiredCheckSatisfiesMergeGate,
+} from "./check-gate";
+
+describe("GitHub required-check merge gate", () => {
+  it("keeps review_required in_progress with no conclusion", () => {
+    expect(REVIEW_REQUIRED_GITHUB_CHECK).toEqual({
+      status: "in_progress",
+      conclusion: null,
+    });
+  });
+
+  it("does not treat waiting-for-review as a satisfied required check", () => {
+    expect(
+      requiredCheckSatisfiesMergeGate(
+        REVIEW_REQUIRED_GITHUB_CHECK.status,
+        REVIEW_REQUIRED_GITHUB_CHECK.conclusion,
+      ),
+    ).toBe(false);
+    expect(requiredCheckSatisfiesMergeGate("queued", null)).toBe(false);
+    expect(requiredCheckSatisfiesMergeGate("in_progress", null)).toBe(false);
+  });
+
+  it("treats completed+neutral as a satisfied required check, so it cannot wait for review", () => {
+    expect(requiredCheckSatisfiesMergeGate("completed", "neutral")).toBe(true);
+    expect(
+      requiredCheckSatisfiesMergeGate(
+        TECHNICAL_RETRY_GITHUB_CHECK.status,
+        TECHNICAL_RETRY_GITHUB_CHECK.conclusion,
+      ),
+    ).toBe(true);
+    expect(REVIEW_REQUIRED_GITHUB_CHECK).not.toEqual(
+      TECHNICAL_RETRY_GITHUB_CHECK,
+    );
+    expect(REVIEW_REQUIRED_GITHUB_CHECK.conclusion).not.toBe("neutral");
+    expect(REVIEW_REQUIRED_GITHUB_CHECK.status).not.toBe("completed");
+  });
+
+  it("blocks merge on maintainer reject and allows it only after approve", () => {
+    expect(
+      requiredCheckSatisfiesMergeGate("completed", "action_required"),
+    ).toBe(false);
+    expect(requiredCheckSatisfiesMergeGate("completed", "success")).toBe(true);
+    expect(requiredCheckSatisfiesMergeGate("completed", "cancelled")).toBe(
+      false,
+    );
+  });
+});

--- a/packages/github/src/check-gate.ts
+++ b/packages/github/src/check-gate.ts
@@ -1,0 +1,39 @@
+/**
+ * GitHub required status checks treat `queued` / `in_progress` as pending
+ * (merge blocked) and treat `completed` + `neutral` as successful (merge
+ * allowed). Waiting for a maintainer must therefore stay pending. `neutral`
+ * is only for a true technical retry, never for "waiting for human review".
+ */
+export const REVIEW_REQUIRED_GITHUB_CHECK = {
+  status: "in_progress",
+  conclusion: null,
+} as const;
+
+export const TECHNICAL_RETRY_GITHUB_CHECK = {
+  status: "completed",
+  conclusion: "neutral",
+} as const;
+
+export type RequiredCheckStatus = "queued" | "in_progress" | "completed";
+export type RequiredCheckConclusion =
+  | "action_required"
+  | "success"
+  | "neutral"
+  | "cancelled"
+  | "skipped"
+  | "failure"
+  | "timed_out"
+  | "stale"
+  | null;
+
+export function requiredCheckSatisfiesMergeGate(
+  status: RequiredCheckStatus,
+  conclusion: RequiredCheckConclusion,
+): boolean {
+  if (status !== "completed" || conclusion === null) return false;
+  return (
+    conclusion === "success" ||
+    conclusion === "neutral" ||
+    conclusion === "skipped"
+  );
+}

--- a/packages/github/src/check-run.test.ts
+++ b/packages/github/src/check-run.test.ts
@@ -95,36 +95,173 @@ describe("OctokitCheckRunAdapter", () => {
     );
   });
 
-  it("fails closed for duplicate replay matches or an unbounded result set", async () => {
-    const write = vi.fn();
-    const duplicates = new OctokitCheckRunAdapter(tokenProvider(), headPort(), {
+  it("reuses the latest open check when GitHub lists superseded runs", async () => {
+    const createCheckRun = vi.fn();
+    const updateCheckRun = vi.fn(async () => ({
+      data: checkRun(702),
+    }));
+    const adapter = new OctokitCheckRunAdapter(tokenProvider(), headPort(), {
       clientFactory: () =>
         githubRestClientStub({
           listCheckRunsForRef: async () => ({
             data: {
               total_count: 2,
-              check_runs: [checkRun(701), checkRun(702)],
+              check_runs: [
+                checkRun(701, {
+                  status: "completed",
+                  conclusion: "neutral",
+                }),
+                checkRun(702),
+              ],
             },
           }),
-          createCheckRun: write,
-          updateCheckRun: write,
+          createCheckRun,
+          updateCheckRun,
         }),
     });
-    await expect(duplicates.create(intent)).rejects.toMatchObject({
-      code: "INVALID_RESPONSE",
+    await expect(adapter.create(intent)).resolves.toEqual({
+      checkRunId: "702",
     });
-    expect(write).not.toHaveBeenCalled();
+    expect(createCheckRun).not.toHaveBeenCalled();
+    expect(updateCheckRun).toHaveBeenCalledWith(
+      expect.objectContaining({ checkRunId: 702 }),
+      expect.any(AbortSignal),
+    );
+  });
 
+  it("fails closed for an unbounded result set", async () => {
+    const write = vi.fn();
     const unbounded = new OctokitCheckRunAdapter(tokenProvider(), headPort(), {
       clientFactory: () =>
         githubRestClientStub({
           listCheckRunsForRef: async () => ({
             data: { total_count: 301, check_runs: [] },
           }),
+          createCheckRun: write,
+          updateCheckRun: write,
         }),
     });
     await expect(unbounded.create(intent)).rejects.toMatchObject({
       code: "LIMIT_EXCEEDED",
+    });
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("creates a new pending run when the listed check is already completed", async () => {
+    const updateCheckRun = vi.fn();
+    const createCheckRun = vi.fn(async () => ({
+      data: checkRun(802),
+    }));
+    const adapter = new OctokitCheckRunAdapter(tokenProvider(), headPort(), {
+      clientFactory: () =>
+        githubRestClientStub({
+          listCheckRunsForRef: async () => ({
+            data: {
+              total_count: 1,
+              check_runs: [
+                checkRun(701, {
+                  status: "completed",
+                  conclusion: "neutral",
+                }),
+              ],
+            },
+          }),
+          createCheckRun,
+          updateCheckRun,
+        }),
+    });
+    await expect(adapter.create(intent)).resolves.toEqual({
+      checkRunId: "802",
+    });
+    expect(updateCheckRun).not.toHaveBeenCalled();
+    expect(createCheckRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "in_progress",
+        conclusion: null,
+      }),
+      expect.any(AbortSignal),
+    );
+  });
+
+  it("creates a new pending run when update completes a review_required check as neutral", async () => {
+    const createCheckRun = vi.fn(async () => ({
+      data: checkRun(802),
+    }));
+    const updateCheckRun = vi.fn(async () => ({
+      data: checkRun(701, {
+        status: "completed",
+        conclusion: "neutral",
+      }),
+    }));
+    const adapter = new OctokitCheckRunAdapter(tokenProvider(), headPort(), {
+      clientFactory: () =>
+        githubRestClientStub({
+          getCheckRun: async () => ({ data: checkRun(701) }),
+          updateCheckRun,
+          createCheckRun,
+        }),
+    });
+    await expect(
+      adapter.update({
+        ...intent,
+        checkRunId: "701",
+        summary: "maintainer review required for head " + headSha,
+      }),
+    ).resolves.toEqual({ checkRunId: "802" });
+    expect(updateCheckRun).toHaveBeenCalledOnce();
+    expect(createCheckRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "in_progress",
+        conclusion: null,
+        summary: "maintainer review required for head " + headSha,
+      }),
+      expect.any(AbortSignal),
+    );
+  });
+
+  it("does not try to reopen a persisted completed run for an in_progress intent", async () => {
+    const updateCheckRun = vi.fn();
+    const createCheckRun = vi.fn(async () => ({
+      data: checkRun(802),
+    }));
+    const adapter = new OctokitCheckRunAdapter(tokenProvider(), headPort(), {
+      clientFactory: () =>
+        githubRestClientStub({
+          getCheckRun: async () => ({
+            data: checkRun(701, {
+              status: "completed",
+              conclusion: "neutral",
+            }),
+          }),
+          updateCheckRun,
+          createCheckRun,
+        }),
+    });
+    await expect(
+      adapter.update({ ...intent, checkRunId: "701" }),
+    ).resolves.toEqual({ checkRunId: "802" });
+    expect(updateCheckRun).not.toHaveBeenCalled();
+    expect(createCheckRun).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a create that GitHub completes while the intent is still pending", async () => {
+    const createCheckRun = vi.fn(async () => ({
+      data: checkRun(701, {
+        status: "completed",
+        conclusion: "neutral",
+      }),
+    }));
+    const adapter = new OctokitCheckRunAdapter(tokenProvider(), headPort(), {
+      clientFactory: () =>
+        githubRestClientStub({
+          listCheckRunsForRef: async () => ({
+            data: { total_count: 0, check_runs: [] },
+          }),
+          createCheckRun,
+        }),
+    });
+    await expect(adapter.create(intent)).rejects.toMatchObject({
+      code: "INVALID_RESPONSE",
     });
   });
 
@@ -342,6 +479,8 @@ function checkRun(id: number, overrides: Record<string, unknown> = {}) {
     name: GITHUB_CHECK_NAME,
     head_sha: headSha,
     external_id: revisionId,
+    status: "in_progress",
+    conclusion: null,
     ...overrides,
   };
 }

--- a/packages/github/src/check-run.ts
+++ b/packages/github/src/check-run.ts
@@ -26,12 +26,34 @@ import {
   type GithubRequestPolicy,
 } from "./request-policy";
 
+const remoteCheckStatusSchema = z.enum([
+  "queued",
+  "in_progress",
+  "completed",
+  "waiting",
+  "requested",
+  "pending",
+]);
+const remoteCheckConclusionSchema = z
+  .enum([
+    "action_required",
+    "cancelled",
+    "failure",
+    "neutral",
+    "success",
+    "skipped",
+    "stale",
+    "timed_out",
+  ])
+  .nullable();
 const upstreamCheckRunSchema = z
   .object({
     id: z.number().int().positive().safe(),
     name: z.string(),
     head_sha: z.string().regex(/^[0-9a-f]{40}$/u),
     external_id: z.string().nullable(),
+    status: remoteCheckStatusSchema,
+    conclusion: remoteCheckConclusionSchema,
   })
   .passthrough();
 const upstreamCheckRunListSchema = z
@@ -67,36 +89,16 @@ export class OctokitCheckRunAdapter implements GithubCheckRunPort {
     if (!parsed.success) throw new GithubControlError("INVALID_INPUT");
     const input = parsed.data;
     const client = await this.createClient(input);
-    let existing: CheckRunReference | undefined;
     try {
-      existing =
-        (await this.findExistingWithClient(client, input)) ?? undefined;
+      const existing = await this.findExistingWithClient(client, input);
       await this.assertCurrentHead(input);
-      const existingCheckRunId = existing?.checkRunId;
-      const response = existingCheckRunId
-        ? await this.executeWrite((signal) =>
-            client.updateCheckRun(
-              checkUpdateRequest(input, existingCheckRunId),
-              signal,
-            ),
-          )
-        : await this.executeWrite((signal) =>
-            client.createCheckRun(
-              {
-                owner: input.owner,
-                repositoryName: input.repositoryName,
-                name: GITHUB_CHECK_NAME,
-                headSha: input.headSha,
-                detailsUrl: input.detailsUrl,
-                externalId: input.revisionId,
-                status: input.status,
-                conclusion: input.conclusion,
-                summary: input.summary,
-              },
-              signal,
-            ),
-          );
-      return parseCheckRunResponse(response.data, input, existingCheckRunId);
+      return await this.applyIntent(
+        client,
+        input,
+        existing && canReuseRemoteCheck(existing, input)
+          ? existing.checkRunId
+          : undefined,
+      );
     } catch (error) {
       this.invalidateRejectedToken(input, error);
       throw error;
@@ -121,15 +123,13 @@ export class OctokitCheckRunAdapter implements GithubCheckRunPort {
           ),
         this.requestPolicy,
       );
-      parseCheckRunResponse(persisted.data, input, input.checkRunId);
+      const remote = parseRemoteCheck(persisted.data, input, input.checkRunId);
       await this.assertCurrentHead(input);
-      const response = await this.executeWrite((signal) =>
-        client.updateCheckRun(
-          checkUpdateRequest(input, input.checkRunId),
-          signal,
-        ),
+      return await this.applyIntent(
+        client,
+        input,
+        canReuseRemoteCheck(remote, input) ? input.checkRunId : undefined,
       );
-      return parseCheckRunResponse(response.data, input, input.checkRunId);
     } catch (error) {
       this.invalidateRejectedToken(input, error);
       throw error;
@@ -162,7 +162,7 @@ export class OctokitCheckRunAdapter implements GithubCheckRunPort {
           ),
         this.requestPolicy,
       );
-      parseCheckRunResponse(persisted.data, input, input.checkRunId);
+      parseRemoteCheck(persisted.data, input, input.checkRunId);
       const current = await this.pullRequestHeadPort.getCurrentHead({
         installationId: input.installationId,
         repositoryId: input.repositoryId,
@@ -182,7 +182,11 @@ export class OctokitCheckRunAdapter implements GithubCheckRunPort {
           signal,
         ),
       );
-      return parseCheckRunResponse(response.data, input, input.checkRunId);
+      const remote = parseRemoteCheck(response.data, input, input.checkRunId);
+      if (!remoteMatchesIntent(remote, input)) {
+        throw new GithubControlError("INVALID_RESPONSE");
+      }
+      return { checkRunId: remote.checkRunId };
     } catch (error) {
       this.invalidateRejectedToken(input, error);
       throw error;
@@ -197,21 +201,82 @@ export class OctokitCheckRunAdapter implements GithubCheckRunPort {
     const input = parsed.data;
     const client = await this.createClient(input);
     try {
-      return await this.findExistingWithClient(client, input);
+      const existing = await this.findExistingWithClient(client, input);
+      return existing ? { checkRunId: existing.checkRunId } : null;
     } catch (error) {
       this.invalidateRejectedToken(input, error);
       throw error;
     }
   }
 
+  /**
+   * GitHub cannot reopen a completed check run. An in_progress update can also
+   * land as completed+neutral. In either case a new run with the same name
+   * supersedes the old one and keeps a required check pending.
+   */
+  private async applyIntent(
+    client: GithubRestClient,
+    input: CheckIntentInput,
+    existingCheckRunId: string | undefined,
+  ): Promise<CheckRunReference> {
+    if (existingCheckRunId !== undefined) {
+      const updated = await this.writeUpdate(client, input, existingCheckRunId);
+      if (remoteMatchesIntent(updated, input)) {
+        return { checkRunId: updated.checkRunId };
+      }
+      if (!shouldCreateSupersedingCheck(updated, input)) {
+        throw new GithubControlError("INVALID_RESPONSE");
+      }
+    }
+    return this.writeCreate(client, input);
+  }
+
+  private async writeCreate(
+    client: GithubRestClient,
+    input: CheckIntentInput,
+  ): Promise<CheckRunReference> {
+    const response = await this.executeWrite((signal) =>
+      client.createCheckRun(
+        {
+          owner: input.owner,
+          repositoryName: input.repositoryName,
+          name: GITHUB_CHECK_NAME,
+          headSha: input.headSha,
+          detailsUrl: input.detailsUrl,
+          externalId: input.revisionId,
+          status: input.status,
+          conclusion: input.conclusion,
+          summary: input.summary,
+        },
+        signal,
+      ),
+    );
+    const remote = parseRemoteCheck(response.data, input);
+    if (!remoteMatchesIntent(remote, input)) {
+      throw new GithubControlError("INVALID_RESPONSE");
+    }
+    return { checkRunId: remote.checkRunId };
+  }
+
+  private async writeUpdate(
+    client: GithubRestClient,
+    input: CheckIntentInput,
+    checkRunId: string,
+  ): Promise<RemoteCheck> {
+    const response = await this.executeWrite((signal) =>
+      client.updateCheckRun(checkUpdateRequest(input, checkRunId), signal),
+    );
+    return parseRemoteCheck(response.data, input, checkRunId);
+  }
+
   private async findExistingWithClient(
     client: GithubRestClient,
     input: CheckIntentInput,
-  ): Promise<CheckRunReference | null> {
+  ): Promise<RemoteCheck | null> {
     let page = 1;
     let expectedTotal: number | undefined;
     let seen = 0;
-    let match: CheckRunReference | undefined;
+    const matches: RemoteCheck[] = [];
 
     do {
       const response = await executeGithubRequest(
@@ -257,16 +322,26 @@ export class OctokitCheckRunAdapter implements GithubCheckRunPort {
           check.name === GITHUB_CHECK_NAME &&
           check.external_id === input.revisionId
         ) {
-          if (check.head_sha !== input.headSha || match !== undefined) {
+          if (check.head_sha !== input.headSha) {
             throw new GithubControlError("INVALID_RESPONSE");
           }
-          match = { checkRunId: String(check.id) };
+          const reference = CheckRunReferenceSchema.safeParse({
+            checkRunId: String(check.id),
+          });
+          if (!reference.success) {
+            throw new GithubControlError("INVALID_RESPONSE");
+          }
+          matches.push({
+            checkRunId: reference.data.checkRunId,
+            status: check.status,
+            conclusion: check.conclusion,
+          });
         }
       }
       page += 1;
     } while (seen < (expectedTotal ?? 0));
 
-    return match ?? null;
+    return selectReusableRemote(matches, input);
   }
 
   private async assertCurrentHead(input: CheckIntentInput): Promise<void> {
@@ -366,11 +441,17 @@ function checkUpdateRequest(input: CheckIntentInput, checkRunId: string) {
   };
 }
 
-function parseCheckRunResponse(
+type RemoteCheck = {
+  checkRunId: string;
+  status: z.infer<typeof remoteCheckStatusSchema>;
+  conclusion: z.infer<typeof remoteCheckConclusionSchema>;
+};
+
+function parseRemoteCheck(
   value: unknown,
   input: CheckIntentInput,
-  expectedCheckRunId: string | undefined,
-): CheckRunReference {
+  expectedCheckRunId?: string,
+): RemoteCheck {
   const parsed = upstreamCheckRunSchema.safeParse(value);
   if (
     !parsed.success ||
@@ -386,5 +467,48 @@ function parseCheckRunResponse(
     checkRunId: String(parsed.data.id),
   });
   if (!reference.success) throw new GithubControlError("INVALID_RESPONSE");
-  return reference.data;
+  return {
+    checkRunId: reference.data.checkRunId,
+    status: parsed.data.status,
+    conclusion: parsed.data.conclusion,
+  };
+}
+
+function canReuseRemoteCheck(
+  remote: RemoteCheck,
+  intent: CheckIntentInput,
+): boolean {
+  return intent.status === "completed" || remote.status !== "completed";
+}
+
+function shouldCreateSupersedingCheck(
+  remote: RemoteCheck,
+  intent: CheckIntentInput,
+): boolean {
+  return intent.status !== "completed" && remote.status === "completed";
+}
+
+function remoteMatchesIntent(
+  remote: RemoteCheck,
+  intent: CheckIntentInput,
+): boolean {
+  if (intent.status !== "completed") {
+    return remote.status !== "completed" && remote.conclusion === null;
+  }
+  return (
+    remote.status === "completed" && remote.conclusion === intent.conclusion
+  );
+}
+
+function selectReusableRemote(
+  matches: RemoteCheck[],
+  intent: CheckIntentInput,
+): RemoteCheck | null {
+  const open = matches.filter((match) => match.status !== "completed");
+  const pool =
+    intent.status === "completed" && open.length === 0 ? matches : open;
+  if (pool.length === 0) return null;
+  return pool.reduce((latest, current) =>
+    Number(current.checkRunId) > Number(latest.checkRunId) ? current : latest,
+  );
 }

--- a/packages/github/src/index.ts
+++ b/packages/github/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./app-auth";
+export * from "./check-gate";
 export * from "./check-run";
 export * from "./git-tree-metadata";
 export * from "./ingest";

--- a/packages/github/src/octokit-client.test.ts
+++ b/packages/github/src/octokit-client.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { octokitCheckConclusionFields } from "./octokit-client";
+
+describe("octokitCheckConclusionFields", () => {
+  it("omits conclusion while the check is pending", () => {
+    expect(octokitCheckConclusionFields(null)).toEqual({});
+    expect(octokitCheckConclusionFields(null)).not.toHaveProperty("conclusion");
+  });
+
+  it("sends a conclusion only when completing the check", () => {
+    expect(octokitCheckConclusionFields("neutral")).toEqual({
+      conclusion: "neutral",
+    });
+    expect(octokitCheckConclusionFields("success")).toEqual({
+      conclusion: "success",
+    });
+    expect(octokitCheckConclusionFields("action_required")).toEqual({
+      conclusion: "action_required",
+    });
+  });
+});

--- a/packages/github/src/octokit-client.ts
+++ b/packages/github/src/octokit-client.ts
@@ -61,6 +61,15 @@ export type ListCheckRunsForRefRequest = {
   perPage: number;
 };
 
+/** GitHub treats a present `conclusion` as completed; omit it while pending. */
+export function octokitCheckConclusionFields(
+  conclusion: CheckRunRequest["conclusion"],
+):
+  | { conclusion: NonNullable<CheckRunRequest["conclusion"]> }
+  | Record<string, never> {
+  return conclusion === null ? {} : { conclusion };
+}
+
 export type CollaboratorPermissionRequest = {
   owner: string;
   repositoryName: string;
@@ -242,7 +251,7 @@ export class OctokitGithubRestClient implements GithubRestClient {
       details_url: input.detailsUrl,
       external_id: input.externalId,
       status: input.status,
-      ...(input.conclusion === null ? {} : { conclusion: input.conclusion }),
+      ...octokitCheckConclusionFields(input.conclusion),
       output: {
         title: input.name,
         summary: input.summary,
@@ -263,7 +272,7 @@ export class OctokitGithubRestClient implements GithubRestClient {
       details_url: input.detailsUrl,
       external_id: input.externalId,
       status: input.status,
-      ...(input.conclusion === null ? {} : { conclusion: input.conclusion }),
+      ...octokitCheckConclusionFields(input.conclusion),
       output: {
         title: input.name,
         summary: input.summary,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Change

A submitted live proof must leave `SlopProof / understanding required` **pending** so GitHub’s required-check merge gate stays closed until a maintainer decides.

The worker already persisted `review_required` as `in_progress` / `conclusion: null`. The GitHub sync path then updated the existing check run and treated the write as successful without checking GitHub’s remote state. GitHub cannot reopen a completed run, and an `in_progress` update can land as `completed` + `neutral`. Required checks treat `neutral` as passing, which is what unblocked squash on PR #13 after the proof landed (check run 96235122208, summary still “maintainer review required”).

This change:

- Locks `review_required` as `in_progress` / `conclusion: null` and documents that `completed` + `neutral` satisfies a required check, so it cannot be the waiting-for-review state.
- Rejects that pairing at persist time.
- Omits `conclusion` on pending Octokit writes (GitHub treats a present conclusion as completed).
- After create/update, requires the remote status to match the intent. If GitHub completed the run or the persisted run cannot be reopened, create a new pending check with the same name so the latest required check stays blocking.

`neutral` remains only for true technical retry. Maintainer approve stays `completed` + `success`; reject stays `completed` + `action_required`.

## Failure mode

If GitHub returns `completed` (especially `neutral`) for a pending intent, sync no longer records that as success. It either opens a new pending run or fails closed as `INVALID_RESPONSE` so the reconcile job can retry. Persist rejects `review_required` + `completed` + `neutral` before a GitHub write is queued.

## Verification

- [x] Unit or contract tests (`772` unit tests passed, including new check-gate, persist, Octokit, and adapter cases)
- [ ] PostgreSQL integration tests when state or concurrency changed (persist contract is unit-tested; no schema migration)
- [ ] Playwright coverage when a user flow changed
- [ ] Threat model or provider data-flow update when a boundary changed
- [x] `pnpm audit:secrets`
- [x] No credentials, private repository data or evidence artifacts included

## Privacy and public output

Public Check output may still say `maintainer review required for head <sha>` while the run stays `in_progress`. No new stored field, provider field, log field, metric label, HTTP route, or GitHub permission.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d51a0a4b-3917-406d-8a29-90f0432d1230?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d51a0a4b-3917-406d-8a29-90f0432d1230&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

