### PR TITLE
fix: show finished judge and quiet maintainer review copy

### DIFF
--- a/apps/web/app/review/[attemptId]/page.tsx
+++ b/apps/web/app/review/[attemptId]/page.tsx
@@ -9,10 +9,7 @@ import {
   hasPrivateReviewContextMetadata,
   loadPrivateReviewContext,
 } from "../../../lib/private-review-context";
-import {
-  buildMaintainerReviewView,
-  JUDGE_DID_NOT_FINISH,
-} from "../../../lib/review-page-model";
+import { buildMaintainerReviewView } from "../../../lib/review-page-model";
 import { ReviewAttemptIdSchema } from "../../../lib/review-http";
 import { getWebRuntime } from "../../../lib/runtime";
 import { WebRequestRateLimitExceededError } from "../../../lib/request-rate-limit";
@@ -118,7 +115,7 @@ export default async function ReviewDetailPage({
           <p className="eyebrow">
             {detail.repository} · PR #{detail.pullRequestNumber}
           </p>
-          <h1 className="flow-title">Review the proof, not a score.</h1>
+          <h1 className="flow-title">Proof</h1>
         </div>
         <span className="status-pill">{humanStatus(detail.status)}</span>
       </div>
@@ -151,9 +148,7 @@ export default async function ReviewDetailPage({
         <QuestionReviewList questions={review.questions} />
 
         <div className="review-video-column">
-          {review.judgeUnavailable ? (
-            <section className="notice-card">{JUDGE_DID_NOT_FINISH}</section>
-          ) : review.recommendationLabel ? (
+          {review.recommendationLabel ? (
             <section className="model-context-card">
               <p className="eyebrow">Judge</p>
               <h2>Recommendation</h2>

--- a/apps/web/app/review/[attemptId]/review-decision-form.tsx
+++ b/apps/web/app/review/[attemptId]/review-decision-form.tsx
@@ -79,14 +79,14 @@ export function ReviewDecisionForm({
       className="review-decision-card"
       aria-labelledby="decision-heading"
     >
-      <p className="eyebrow">Human decision only</p>
-      <h2 id="decision-heading">Decide for this exact SHA.</h2>
+      <p className="eyebrow">Decision</p>
+      <h2 id="decision-heading">Decide for this SHA</h2>
       <label htmlFor="review-explanation">Reason or reviewer note</label>
       <textarea
         id="review-explanation"
         maxLength={2_000}
         onChange={(event) => setExplanation(event.target.value)}
-        placeholder="Optional, private and audit-bound"
+        placeholder="Optional reviewer note"
         rows={5}
         value={explanation}
       />
@@ -118,8 +118,7 @@ export function ReviewDecisionForm({
       </div>
       <p className="review-help">
         Approve passes the current SHA. Reject requests a new contributor proof.
-        Technical retry records a neutral system retry. The model cannot trigger
-        any of these actions.
+        Technical retry records a neutral system retry.
       </p>
       <div aria-live="polite">
         {state.kind === "submitting" ? (

--- a/apps/web/app/review/page.tsx
+++ b/apps/web/app/review/page.tsx
@@ -71,16 +71,10 @@ export default async function ReviewQueuePage({
               Protected queue · {queue.authorization.owner}/
               {queue.authorization.name}
             </p>
-            <h1 className="flow-title">
-              Human review, bound to the current SHA.
-            </h1>
+            <h1 className="flow-title">Review queue</h1>
           </div>
           <span className="status-pill">{queue.items.length} open</span>
         </div>
-        <p className="lede">
-          Model output is context, never the decision. Every detail view,
-          evidence stream and maintainer action is authorized again and audited.
-        </p>
         {queue.items.length === 0 ? (
           <section className="notice-card review-empty">
             <h2>Nothing waiting.</h2>

--- a/apps/web/lib/review-page-model.test.ts
+++ b/apps/web/lib/review-page-model.test.ts
@@ -68,8 +68,8 @@ describe("maintainer review copy", () => {
       authorId: "500004",
       authorLogin: "octocat",
       recommendation: "review_required",
-      evaluationModel: "judge-model",
-      evaluationProvider: "hetzner-inference",
+      evaluationModel: "manual-review-projection-v1",
+      evaluationProvider: "multimodal-compatibility-v1",
       questions: [
         {
           id: QUESTION_ID,
@@ -117,21 +117,49 @@ describe("maintainer review copy", () => {
     );
   });
 
-  it("does not present a fallback or compatibility projection as a model opinion", () => {
+  it("shows a generated sidecar even when evaluations is the persistPair stub", () => {
+    const view = buildMaintainerReviewView({
+      authorId: "99",
+      authorLogin: "octocat",
+      recommendation: "review_required",
+      evaluationModel: "manual-review-projection-v1",
+      evaluationProvider: "multimodal-compatibility-v1",
+      questions: [questionFixture()],
+      privateContext: persistPairGeneratedContext(),
+    });
+    expect(
+      isAutomatedJudgeUnavailable({
+        evaluationModel: "manual-review-projection-v1",
+        evaluationProvider: "multimodal-compatibility-v1",
+        privateContext: persistPairGeneratedContext(),
+      }),
+    ).toBe(false);
+    expect(view.judgeUnavailable).toBe(false);
+    expect(view.recommendationLabel).toBe("Needs a look");
+    expect(view.questions[0]?.judgeFinished).toBe(true);
+    expect(view.questions[0]?.judgeOpinion).toBe(
+      "The judge thinks the spoken answer missed required points. The spoken answer conflicts with the patch.",
+    );
+    expect(JSON.stringify(view)).not.toContain("Judge did not finish");
+  });
+
+  it("treats a fallback or missing sidecar as an unfinished judge", () => {
     const fallback = buildMaintainerReviewView({
       authorId: "99",
       authorLogin: null,
       recommendation: "review_required",
-      evaluationModel: "judge-model",
-      evaluationProvider: "hetzner-inference",
+      evaluationModel: "manual-review-projection-v1",
+      evaluationProvider: "multimodal-compatibility-v1",
       questions: [questionFixture()],
       privateContext: fallbackContext(),
     });
+    expect(JUDGE_DID_NOT_FINISH).toBe("Judge did not finish.");
     expect(fallback.judgeUnavailable).toBe(true);
     expect(fallback.recommendationLabel).toBeNull();
     expect(fallback.questions[0]?.judgeOpinion).toBe(JUDGE_DID_NOT_FINISH);
     expect(fallback.questions[0]?.judgeFinished).toBe(false);
     expect(JSON.stringify(fallback)).not.toContain("not_evaluable");
+    expect(JSON.stringify(fallback)).not.toContain("not a model opinion");
 
     const projection = buildMaintainerReviewView({
       authorId: "99",
@@ -157,9 +185,9 @@ describe("maintainer review copy", () => {
     const view = buildMaintainerReviewView({
       authorId: "99",
       authorLogin: "octocat",
-      recommendation: "pass",
-      evaluationModel: "judge-model",
-      evaluationProvider: "hetzner-inference",
+      recommendation: "review_required",
+      evaluationModel: "manual-review-projection-v1",
+      evaluationProvider: "multimodal-compatibility-v1",
       questions: [questionFixture()],
       privateContext: passingContext(),
     });
@@ -171,6 +199,10 @@ describe("maintainer review copy", () => {
   });
 
   it("keeps the maintainer page as question, answer, required points, opinion, video", () => {
+    const queue = readFileSync(
+      new URL("../app/review/page.tsx", import.meta.url),
+      "utf8",
+    );
     const page = readFileSync(
       new URL("../app/review/[attemptId]/page.tsx", import.meta.url),
       "utf8",
@@ -183,6 +215,20 @@ describe("maintainer review copy", () => {
       new URL("../app/review/[attemptId]/evidence-player.tsx", import.meta.url),
       "utf8",
     );
+    const decision = readFileSync(
+      new URL(
+        "../app/review/[attemptId]/review-decision-form.tsx",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    expect(queue).toContain("Review queue");
+    expect(queue).not.toContain("Human review");
+    expect(queue).not.toContain("never the decision");
+    expect(page).toContain(">Proof<");
+    expect(page).not.toContain("not a score");
+    expect(page).not.toContain("JUDGE_DID_NOT_FINISH");
+    expect(page).toContain("recommendationLabel");
     expect(questions).toContain("Spoken answer");
     expect(questions).toContain("Needed in the answer");
     expect(questions).toContain("Judge opinion");
@@ -194,6 +240,9 @@ describe("maintainer review copy", () => {
     expect(page).not.toContain("Transcript-aligned frames");
     expect(player).toContain("Watch the proof");
     expect(player).not.toContain("Selected frame");
+    expect(decision).toContain("Decide for this SHA");
+    expect(decision).not.toContain("Human decision only");
+    expect(decision).not.toContain("The model cannot");
   });
 
   it("keeps missing transcript honest and does not invent an answer", () => {
@@ -208,14 +257,32 @@ describe("maintainer review copy", () => {
     });
     expect(view.questions[0]?.spokenAnswer).toBe(SPOKEN_ANSWER_UNAVAILABLE);
     expect(view.questions[0]?.judgeOpinion).toBe(JUDGE_OPINION_UNAVAILABLE);
+    expect(view.judgeUnavailable).toBe(true);
+    expect(view.recommendationLabel).toBeNull();
     expect(view.videoMarkers).toEqual([]);
+
+    const stubWithoutContext = buildMaintainerReviewView({
+      authorId: "99",
+      authorLogin: "octocat",
+      recommendation: "review_required",
+      evaluationModel: "manual-review-projection-v1",
+      evaluationProvider: "multimodal-compatibility-v1",
+      questions: [questionFixture()],
+      privateContext: null,
+    });
+    expect(stubWithoutContext.judgeUnavailable).toBe(true);
+    expect(stubWithoutContext.recommendationLabel).toBeNull();
+    expect(stubWithoutContext.questions[0]?.judgeOpinion).toBe(
+      JUDGE_OPINION_UNAVAILABLE,
+    );
+    expect(stubWithoutContext.questions[0]?.judgeFinished).toBe(false);
 
     const unbound = buildMaintainerReviewView({
       authorId: "99",
       authorLogin: "octocat",
-      recommendation: "pass",
-      evaluationModel: "judge-model",
-      evaluationProvider: "hetzner-inference",
+      recommendation: "review_required",
+      evaluationModel: "manual-review-projection-v1",
+      evaluationProvider: "multimodal-compatibility-v1",
       questions: [questionFixture()],
       privateContext: scoredContext({ bindTranscript: false }),
     });
@@ -243,6 +310,29 @@ function scoredContext(
     fallback: false,
     bindTranscript: options.bindTranscript ?? true,
   });
+}
+
+function persistPairGeneratedContext(): PrivateReviewContext {
+  const context = scoredContext();
+  if (
+    context.schemaVersion !== "2" ||
+    context.authoritativeEvaluation === null
+  ) {
+    throw new Error("expected generated V2 sidecar");
+  }
+  return {
+    ...context,
+    authoritativeEvaluation: {
+      ...context.authoritativeEvaluation,
+      invocationMetadata: {
+        ...context.authoritativeEvaluation.invocationMetadata,
+        provider: "openrouter",
+        model: "xiaomi/mimo-v2.5",
+        outcome: "generated",
+        degraded: false,
+      },
+    },
+  };
 }
 
 function passingContext(): PrivateReviewContext {

--- a/apps/web/lib/review-page-model.ts
+++ b/apps/web/lib/review-page-model.ts
@@ -5,10 +5,8 @@ import type {
   TranscriptV1,
 } from "@slopproof/providers";
 
-export const JUDGE_DID_NOT_FINISH =
-  "Judge did not finish; this is not a model opinion.";
-export const GITHUB_CHECK_NOTICE =
-  "This recommendation cannot update the GitHub check.";
+export const JUDGE_DID_NOT_FINISH = "Judge did not finish.";
+export const GITHUB_CHECK_NOTICE = "Does not update the GitHub check.";
 export const SPOKEN_ANSWER_UNAVAILABLE = "Spoken answer is not available.";
 export const SPOKEN_ANSWER_UNBOUND =
   "No spoken answer was bound to this question.";
@@ -105,14 +103,17 @@ export function isAutomatedJudgeUnavailable(input: {
   evaluationProvider?: string | null;
   privateContext: PrivateReviewContext | null;
 }): boolean {
-  if (isCompatibilityOnlyProjection(input)) return true;
-  if (input.privateContext === null) return false;
-  if (input.privateContext.schemaVersion === "1") {
+  // persistPair always writes evaluations.provider/model as the conservative
+  // compatibility stub. Those columns are not evidence the judge failed.
+  // Availability comes from the decrypted sidecar / private review context.
+  const context = input.privateContext;
+  if (context === null) return true;
+  if (context.schemaVersion === "1") {
     return isCompatibilityOnlyProjection({
-      evaluation: input.privateContext.evaluation,
+      evaluation: context.evaluation,
     });
   }
-  const evaluation = input.privateContext.authoritativeEvaluation;
+  const evaluation = context.authoritativeEvaluation;
   if (evaluation === null) return true;
   return isAuthoritativeFallback(evaluation);
 }
@@ -193,8 +194,8 @@ function judgeOpinionForQuestion(input: {
   judgeUnavailable: boolean;
   privateContext: PrivateReviewContext | null;
 }): string {
-  if (input.judgeUnavailable) return JUDGE_DID_NOT_FINISH;
   if (input.privateContext === null) return JUDGE_OPINION_UNAVAILABLE;
+  if (input.judgeUnavailable) return JUDGE_DID_NOT_FINISH;
   if (input.privateContext.schemaVersion === "1") {
     return legacyJudgeOpinion(
       input.privateContext.evaluation.questionEvaluations.find(

--- a/tests/e2e/mvp-ui.spec.ts
+++ b/tests/e2e/mvp-ui.spec.ts
@@ -247,10 +247,10 @@ test("requires a repository-bound maintainer session for review", async ({
   ).toBeVisible();
   await page.getByRole("button", { name: "Enter as demo maintainer" }).click();
   await expect(
-    page.getByRole("heading", {
-      name: "Human review, bound to the current SHA.",
-    }),
+    page.getByRole("heading", { name: "Review queue" }),
   ).toBeVisible();
+  await expect(page.getByText(/never the decision/i)).toHaveCount(0);
+  await expect(page.getByText(/Human review/i)).toHaveCount(0);
   await expect(
     page.getByRole("heading", { name: "Nothing waiting." }),
   ).toBeVisible();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Change

Production `/review` still read as manifesto after #21 because the headings announced human review and denied the model. The judge card was also wrong on a finished proof.

`persistPair` always writes the `evaluations` row as the conservative compatibility stub (`provider=multimodal-compatibility-v1`, `model=manual-review-projection-v1`) next to the encrypted sidecar. Attempt `0d33bf08-093c-54ac-bf09-57aafa0f000c` had a completed OpenRouter `xiaomi/mimo-v2.5` sidecar, and the page still showed “Judge did not finish” because `isAutomatedJudgeUnavailable` short-circuited on those stub columns.

This PR:

- Treats judge availability from the decrypted sidecar / private review context, not from evaluations-table stub metadata.
- Shows the Judge card and per-question opinion when the authoritative invocation is a real generated (or repaired) result.
- If the sidecar is actually fallback, or there is no sidecar, keeps a short factual status (`Judge did not finish.`) and omits the recommendation card. A missing context load says the opinion is unavailable. No “not a model opinion” sermon.
- Quiets live maintainer copy:
  - Queue h1: `Review queue` (eyebrow still names the repo; each row still shows the SHA)
  - Queue lede removed
  - Detail h1: `Proof`
  - Decision chrome no longer announces “human only” or that the model cannot act
- Leaves auth walls, the private repo list, review layout (question → answer → missing → judge → video), and judge prompts/generation unchanged.
- Does not touch #20 (landing/docs polish). Does not merge.

## Failure mode

- Generated sidecar + stub evaluations row: show the sidecar. This is the normal `persistPair` pair, not a failed judge.
- Authoritative invocation `outcome=fallback` (or the other fallback sentinels): omit the recommendation card; question-level copy is `Judge did not finish.`
- Private context missing: do not invent a recommendation from the stub row; show `No judge opinion is available for this question.`
- Compatibility-only context with no sidecar: same quiet unfinished status.
- Unauthenticated `/review` still does not list installations.

## Verification

- [x] Unit or contract tests (`pnpm test`: 807 passed, including persistPair stub + generated sidecar, fallback, missing context, and copy pins)
- [ ] PostgreSQL integration tests when state or concurrency changed (none)
- [x] Playwright coverage when a user flow changed (queue h1 + manifesto strings gone; waiting on CI e2e)
- [ ] Threat model or provider data-flow update when a boundary changed (none)
- [x] `pnpm typecheck` and eslint/prettier on the changed files
- [x] No credentials, private repository data or evidence artifacts included
- [x] No `DESLOP_REVIEW.md` in the repo; rationale is this PR body only

## Privacy and public output

none

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed257127-a595-4477-ada8-ec99912b18c9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed257127-a595-4477-ada8-ec99912b18c9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

