### PR TITLE
fix: hop judge after 402/404 and evaluate without frames

### DIFF
--- a/apps/worker/src/multimodal-judge-service.test.ts
+++ b/apps/worker/src/multimodal-judge-service.test.ts
@@ -86,8 +86,7 @@ describe("multimodal judge service", () => {
     );
     expect(provider.evaluate).toHaveBeenCalledOnce();
     const observedInput = provider.evaluate.mock.calls[0]?.[0] as
-      | MultimodalJudgeProviderInputV1
-      | undefined;
+      MultimodalJudgeProviderInputV1 | undefined;
     expect(observedInput?.frames).toEqual([]);
     expect(observedInput?.transcriptSegments).toHaveLength(1);
     expect(observedInput?.transcriptSegments[0]?.questionId).toBe(QUESTION_ID);

--- a/apps/worker/src/multimodal-judge-service.test.ts
+++ b/apps/worker/src/multimodal-judge-service.test.ts
@@ -70,7 +70,7 @@ describe("multimodal judge service", () => {
     expect(frameBytes).toEqual(new Uint8Array(4));
   });
 
-  it("does not invoke the provider when no normalized frame is available", async () => {
+  it("invokes the provider with the transcript when no normalized frame is available", async () => {
     const provider = successfulProvider();
     const result = await runMultimodalJudgeEvaluation(
       inputFixture(),
@@ -84,27 +84,29 @@ describe("multimodal judge service", () => {
         now: () => NOW,
       },
     );
-    expect(provider.evaluate).not.toHaveBeenCalled();
+    expect(provider.evaluate).toHaveBeenCalledOnce();
+    const observedInput = provider.evaluate.mock.calls[0]?.[0] as
+      | MultimodalJudgeProviderInputV1
+      | undefined;
+    expect(observedInput?.frames).toEqual([]);
+    expect(observedInput?.transcriptSegments).toHaveLength(1);
+    expect(observedInput?.transcriptSegments[0]?.questionId).toBe(QUESTION_ID);
     expect(result.frameWarnings).toEqual([
       "frame_ciphertext_unavailable",
       "frames_unavailable",
     ]);
-    expect(result.candidate.recommendation).toBe("review_required");
-    expect(
-      result.candidate.questionEvaluations[0]?.criterionResults[0],
-    ).toMatchObject({
-      criterionId: CRITERION_ID,
-      result: "not_evaluable",
-      supportedPatchAnchorIds: [],
-    });
+    expect(result.candidate.recommendation).toBe("pass");
     expect(result.invocationMetadata).toMatchObject({
-      outcome: "fallback",
-      invocationCount: 0,
-      degraded: true,
+      outcome: "generated",
+      invocationCount: 1,
+      degraded: false,
+      model: "judge-text",
     });
+    expect(result.workflowOutcome).toBe("review_required");
+    expect(result.manualReviewRequired).toBe(true);
   });
 
-  it("converts frame-loader failures into a manual-review-safe fallback", async () => {
+  it("invokes the provider after a non-deadline frame-loader failure", async () => {
     const provider = successfulProvider();
     const result = await runMultimodalJudgeEvaluation(
       inputFixture(),
@@ -117,9 +119,52 @@ describe("multimodal judge service", () => {
         now: () => NOW,
       },
     );
-    expect(provider.evaluate).not.toHaveBeenCalled();
+    expect(provider.evaluate).toHaveBeenCalledOnce();
+    expect(provider.evaluate.mock.calls[0]?.[0]?.frames).toEqual([]);
     expect(result.frameWarnings).toEqual(["frames_unavailable"]);
+    expect(result.candidate.recommendation).toBe("pass");
+    expect(result.invocationMetadata.outcome).toBe("generated");
     expect(JSON.stringify(result)).not.toContain("private frame storage");
+  });
+
+  it("keeps evaluate-throw fallback when no normalized frame is available", async () => {
+    const provider: InlineMultimodalJudgeProvider = {
+      descriptor: descriptorFixture(),
+      evaluate: vi.fn(async () => {
+        throw new Error("private raw provider payload and API key");
+      }),
+    };
+    const result = await runMultimodalJudgeEvaluation(
+      inputFixture(),
+      contextFixture(),
+      {
+        provider,
+        loadFrames: vi.fn(async () => ({
+          frames: [],
+          warnings: ["frame_ciphertext_unavailable" as const],
+        })),
+        now: () => NOW,
+      },
+    );
+    expect(provider.evaluate).toHaveBeenCalledOnce();
+    expect(result.frameWarnings).toEqual([
+      "frame_ciphertext_unavailable",
+      "frames_unavailable",
+    ]);
+    expect(result.candidate).toMatchObject({
+      recommendation: "review_required",
+      warnings: [
+        "frame_ciphertext_unavailable",
+        "frames_unavailable",
+        "provider_evaluation_unavailable",
+      ],
+    });
+    expect(result.invocationMetadata).toMatchObject({
+      outcome: "fallback",
+      invocationCount: 0,
+      degraded: true,
+    });
+    expect(JSON.stringify(result)).not.toContain("private raw provider");
   });
 
   it("aborts before provider access and wipes loaded frames when frame work crosses the deadline", async () => {
@@ -330,7 +375,8 @@ describe("multimodal judge service", () => {
         now: () => NOW,
       },
     );
-    expect(result.candidate.recommendation).toBe("review_required");
+    expect(result.candidate.recommendation).toBe("pass");
+    expect(result.frameWarnings).toEqual(["frames_unavailable"]);
     expect([...jpegBytes].every((byte) => byte === 0)).toBe(true);
   });
 

--- a/apps/worker/src/multimodal-judge-service.ts
+++ b/apps/worker/src/multimodal-judge-service.ts
@@ -110,42 +110,33 @@ export async function runMultimodalJudgeEvaluation(
       loadedFrames.frames,
     );
     let providerResult;
-    if (providerInput.frames.length === 0) {
+    try {
+      providerResult = validateMultimodalJudgeProviderResultV1(
+        await runUntilMultimodalDeadline(context.data, now(), () =>
+          dependencies.provider.evaluate(providerInput, context.data),
+        ),
+        providerInput,
+        [
+          dependencies.provider.descriptor,
+          ...(dependencies.provider.transportFallbackDescriptor === undefined
+            ? []
+            : [dependencies.provider.transportFallbackDescriptor]),
+        ],
+      );
+      assertProviderCompletionBounds(
+        providerResult.metadata.completedAt,
+        requestStartedAt,
+        now(),
+        context.data.deadlineAt,
+      );
+    } catch (error) {
+      if (isMultimodalDeadlineError(error)) throw multimodalDeadlineError();
       providerResult = manualReviewFallbackMultimodalJudgeResultV1(
         providerInput,
         dependencies.provider.descriptor,
-        frameWarnings,
+        [...frameWarnings, "provider_evaluation_unavailable"],
         now(),
       );
-    } else {
-      try {
-        providerResult = validateMultimodalJudgeProviderResultV1(
-          await runUntilMultimodalDeadline(context.data, now(), () =>
-            dependencies.provider.evaluate(providerInput, context.data),
-          ),
-          providerInput,
-          [
-            dependencies.provider.descriptor,
-            ...(dependencies.provider.transportFallbackDescriptor === undefined
-              ? []
-              : [dependencies.provider.transportFallbackDescriptor]),
-          ],
-        );
-        assertProviderCompletionBounds(
-          providerResult.metadata.completedAt,
-          requestStartedAt,
-          now(),
-          context.data.deadlineAt,
-        );
-      } catch (error) {
-        if (isMultimodalDeadlineError(error)) throw multimodalDeadlineError();
-        providerResult = manualReviewFallbackMultimodalJudgeResultV1(
-          providerInput,
-          dependencies.provider.descriptor,
-          [...frameWarnings, "provider_evaluation_unavailable"],
-          now(),
-        );
-      }
     }
     const completedAt = now();
     assertBeforeMultimodalDeadline(context.data, completedAt);

--- a/apps/worker/src/provider-pipeline.test.ts
+++ b/apps/worker/src/provider-pipeline.test.ts
@@ -1283,15 +1283,14 @@ describe("provider worker pipeline", () => {
     expect(provider.evaluate).toHaveBeenCalledOnce();
     expect(storage.getObjectStream).not.toHaveBeenCalled();
     const observedInput = provider.evaluate.mock.calls[0]?.[0] as
-      | MultimodalJudgeProviderInputV1
-      | undefined;
+      MultimodalJudgeProviderInputV1 | undefined;
     expect(observedInput?.frames).toEqual([]);
     expect(observedInput?.transcriptSegments.length).toBeGreaterThan(0);
     const authoritative = sidecars.persisted?.multimodalEvaluation;
     expect(authoritative).toMatchObject({
       workflowOutcome: "review_required",
       manualReviewRequired: true,
-      frameWarnings: ["frame_metadata_invalid", "frames_unavailable"],
+      frameWarnings: ["frames_unavailable"],
       candidate: {
         recommendation: "pass",
       },
@@ -1313,20 +1312,15 @@ describe("provider worker pipeline", () => {
     expect(compatibility.recommendation).toBe("review_required");
     expect(compatibility.questionEvaluations[0]).toMatchObject({
       questionId: QUESTION_ID,
-      outcome: "not_evaluable",
-      rubricFindings: [
-        {
+      outcome: "met",
+      rubricFindings: expect.arrayContaining([
+        expect.objectContaining({
           result: "met",
-          reason: "Compatibility-only sentinel; consult authoritative sidecar.",
-        },
-      ],
+          reason:
+            "Compatibility projection: stored criterion has bounded support; consult authoritative sidecar.",
+        }),
+      ]),
     });
-    expect(
-      compatibility.questionEvaluations[0]?.rubricFindings[0]?.criterionId,
-    ).not.toBe(
-      authoritative?.candidate.questionEvaluations[0]?.criterionResults[0]
-        ?.criterionId,
-    );
     const serviceInput = evaluate.mock.calls[0]?.[0];
     expect(serviceInput).toMatchObject({
       attemptId: ATTEMPT_ID,

--- a/apps/worker/src/provider-pipeline.test.ts
+++ b/apps/worker/src/provider-pipeline.test.ts
@@ -519,6 +519,58 @@ function gate6InlineFrameFixture() {
   };
 }
 
+function successfulInlineProvider(): InlineMultimodalJudgeProvider & {
+  evaluate: ReturnType<typeof vi.fn>;
+} {
+  const descriptor = {
+    provider: "hetzner-inference",
+    model: "judge-text",
+    visionModel: "judge-vision",
+  };
+  return {
+    descriptor,
+    evaluate: vi.fn(async (input: MultimodalJudgeProviderInputV1) => {
+      const candidate: MultimodalJudgeCandidateV1 = {
+        schemaVersion: "1",
+        candidateVersion: "multimodal-judge-candidate-v1",
+        recommendation: "pass",
+        questionEvaluations: input.questions.map((question) => ({
+          questionId: question.id,
+          criterionResults: question.criteria.map((criterion) => ({
+            criterionId: criterion.id,
+            result: "met" as const,
+            supportedPatchAnchorIds: question.patchAnchorIds,
+            reason: "patch_evidence_supports_criterion" as const,
+          })),
+          contradictions: [],
+          uncertainty: [],
+        })),
+        privateReason: "all_stored_criteria_supported",
+        warnings: [],
+      };
+      return {
+        candidate,
+        metadata: {
+          schemaVersion: "1" as const,
+          provider: descriptor.provider,
+          model:
+            input.frames.length > 0 ? descriptor.visionModel : descriptor.model,
+          promptVersion: "proof-judge-system-v2" as const,
+          outputSchemaVersion: "multimodal-judge-candidate-v1" as const,
+          inputHash: multimodalJudgeProviderInputHashV1(input),
+          outputHash: multimodalJudgeCandidateHashV1(candidate),
+          tokenUsage: { inputTokens: 100, outputTokens: 50 },
+          latencyMs: 20,
+          invocationCount: 1 as const,
+          outcome: "generated" as const,
+          degraded: false,
+          completedAt: NOW,
+        },
+      };
+    }),
+  };
+}
+
 function unknownIdInlineProvider(): InlineMultimodalJudgeProvider & {
   evaluate: ReturnType<typeof vi.fn>;
 } {
@@ -1194,19 +1246,12 @@ describe("provider worker pipeline", () => {
     expect(base.repository.transitions).toEqual(["PROVIDER_UNAVAILABLE"]);
   });
 
-  it("runs the frozen Gate 6 service once and persists missing frames as authoritative not_evaluable review", async () => {
+  it("runs the frozen Gate 6 service once and still judges from the transcript when frames fail to load", async () => {
     const base = fixture();
     await base.handlers.extractTranscript(extractJob);
     base.dispatcher.jobs.length = 0;
     const sidecars = new InMemoryMultimodalEvaluationRepository();
-    const provider: InlineMultimodalJudgeProvider = {
-      descriptor: {
-        provider: "hetzner-inference",
-        model: "judge-text",
-        visionModel: "judge-vision",
-      },
-      evaluate: vi.fn(),
-    };
+    const provider = successfulInlineProvider();
     const storage = { getObjectStream: vi.fn() };
     const evaluate = vi.fn(runMultimodalJudgeEvaluation);
     const handlers = createProviderPipelineHandlers({
@@ -1235,24 +1280,25 @@ describe("provider worker pipeline", () => {
 
     expect(outcome.outcome).toBe("completed");
     expect(evaluate).toHaveBeenCalledOnce();
-    expect(provider.evaluate).not.toHaveBeenCalled();
+    expect(provider.evaluate).toHaveBeenCalledOnce();
     expect(storage.getObjectStream).not.toHaveBeenCalled();
+    const observedInput = provider.evaluate.mock.calls[0]?.[0] as
+      | MultimodalJudgeProviderInputV1
+      | undefined;
+    expect(observedInput?.frames).toEqual([]);
+    expect(observedInput?.transcriptSegments.length).toBeGreaterThan(0);
     const authoritative = sidecars.persisted?.multimodalEvaluation;
     expect(authoritative).toMatchObject({
       workflowOutcome: "review_required",
       manualReviewRequired: true,
+      frameWarnings: ["frame_metadata_invalid", "frames_unavailable"],
       candidate: {
-        recommendation: "review_required",
-        questionEvaluations: [
-          {
-            criterionResults: expect.arrayContaining([
-              expect.objectContaining({
-                criterionId: expect.any(String),
-                result: "not_evaluable",
-              }),
-            ]),
-          },
-        ],
+        recommendation: "pass",
+      },
+      invocationMetadata: {
+        outcome: "generated",
+        invocationCount: 1,
+        model: "judge-text",
       },
     });
     expect(sidecars.persisted?.evaluationInputHash).toBe(

--- a/packages/providers/src/hetzner-multimodal.test.ts
+++ b/packages/providers/src/hetzner-multimodal.test.ts
@@ -10,6 +10,7 @@ import {
   type MultimodalJudgeProviderInputV1,
 } from "./hetzner-multimodal";
 import type { ProviderContextV1 } from "./contracts";
+import { TransportFallbackMultimodalJudgeProvider } from "./transport-fallback";
 
 const NOW = new Date("2026-08-13T01:00:00.000Z");
 const DEADLINE = new Date(NOW.getTime() + 30_000);
@@ -102,29 +103,32 @@ describe("HetznerMultimodalJudgeProvider", () => {
     expect(JSON.stringify(body)).not.toContain("data:image");
   });
 
-  it("uses the configured vision model only after an explicit primary capability rejection", async () => {
-    const fetchImpl = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(new Response(null, { status: 415 }))
-      .mockResolvedValueOnce(completionResponse(validCandidate()));
-    const result = await providerWith(fetchImpl).evaluate(
-      inputFixture(),
-      contextFixture(),
-    );
+  it.each([400, 404, 415, 422])(
+    "uses the configured vision model after HTTP %s capability rejection",
+    async (status) => {
+      const fetchImpl = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(new Response(null, { status }))
+        .mockResolvedValueOnce(completionResponse(validCandidate()));
+      const result = await providerWith(fetchImpl).evaluate(
+        inputFixture(),
+        contextFixture(),
+      );
 
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
-    expect(JSON.parse(String(fetchImpl.mock.calls[0]?.[1]?.body)).model).toBe(
-      "text-model",
-    );
-    expect(JSON.parse(String(fetchImpl.mock.calls[1]?.[1]?.body)).model).toBe(
-      "vision-model",
-    );
-    expect(result.metadata).toMatchObject({
-      model: "vision-model",
-      invocationCount: 2,
-      outcome: "repaired",
-    });
-  });
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      expect(JSON.parse(String(fetchImpl.mock.calls[0]?.[1]?.body)).model).toBe(
+        "text-model",
+      );
+      expect(JSON.parse(String(fetchImpl.mock.calls[1]?.[1]?.body)).model).toBe(
+        "vision-model",
+      );
+      expect(result.metadata).toMatchObject({
+        model: "vision-model",
+        invocationCount: 2,
+        outcome: "repaired",
+      });
+    },
+  );
 
   it("repairs malformed bounded model content exactly once without resending it", async () => {
     const fetchImpl = vi
@@ -301,6 +305,7 @@ describe("HetznerMultimodalJudgeProvider", () => {
   });
 
   it.each([
+    { name: "402", first: () => new Response(null, { status: 402 }) },
     { name: "408", first: () => new Response(null, { status: 408 }) },
     { name: "429", first: () => new Response(null, { status: 429 }) },
     { name: "503", first: () => new Response(null, { status: 503 }) },
@@ -321,7 +326,32 @@ describe("HetznerMultimodalJudgeProvider", () => {
     expect(result.candidate.recommendation).toBe("pass");
     expect(fetchImpl).toHaveBeenCalledTimes(2);
     expect(sleep).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(String(fetchImpl.mock.calls[0]?.[1]?.body)).model).toBe(
+      "text-model",
+    );
+    expect(JSON.parse(String(fetchImpl.mock.calls[1]?.[1]?.body)).model).toBe(
+      "text-model",
+    );
   });
+
+  it.each([402, 404, 408])(
+    "retries transient HTTP %s on the text model when no frame is available",
+    async (status) => {
+      const fetchImpl = vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(new Response(null, { status }))
+        .mockResolvedValueOnce(completionResponse(validCandidate()));
+      const sleep = vi.fn(async () => undefined);
+      const result = await providerWith(fetchImpl, { sleep }).evaluate(
+        { ...inputFixture(), frames: [] },
+        contextFixture(),
+      );
+      expect(result.candidate.recommendation).toBe("pass");
+      expect(result.metadata.model).toBe("text-model");
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      expect(sleep).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it.each([400, 401, 403, 415, 422])(
     "does not retry terminal HTTP %s without a multimodal capability fallback",
@@ -349,6 +379,197 @@ describe("HetznerMultimodalJudgeProvider", () => {
       expect(fetchImpl).toHaveBeenCalledTimes(1);
     },
   );
+
+  it.each([401, 403])(
+    "keeps HTTP %s terminal even when frames would allow a vision hop",
+    async (status) => {
+      const fetchImpl = vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(
+          new Response(`private-${API_KEY}-${status}`, { status }),
+        );
+      let failure: unknown;
+      try {
+        await providerWith(fetchImpl).evaluate(
+          inputFixture(),
+          contextFixture(),
+        );
+      } catch (error) {
+        failure = error;
+      }
+      expect(failure).toMatchObject({
+        code: "PROVIDER_UNAVAILABLE",
+        disposition: "terminal",
+      });
+      expect(String(failure)).not.toContain(API_KEY);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each([402, 404, 408])(
+    "reports exhausted HTTP %s as retryable so the transport hop can run",
+    async (status) => {
+      const fetchImpl = vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(
+          new Response(`private-body-${status}-${API_KEY}`, { status }),
+        );
+      const sleep = vi.fn(async () => undefined);
+      let failure: unknown;
+      try {
+        await providerWith(fetchImpl, { sleep }).evaluate(
+          { ...inputFixture(), frames: [] },
+          contextFixture(),
+        );
+      } catch (error) {
+        failure = error;
+      }
+      expect(failure).toMatchObject({
+        code: "PROVIDER_UNAVAILABLE",
+        disposition: "retryable",
+      });
+      expect(String(failure)).not.toContain(API_KEY);
+      expect(String(failure)).not.toContain("private-body");
+      expect(fetchImpl).toHaveBeenCalledTimes(3);
+      expect(sleep).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it.each([402, 404, 408])(
+    "retries HTTP %s then hops to the Hetzner judge fallback",
+    async (status) => {
+      const primaryFetch = vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(
+          new Response(`private-body-${status}-${API_KEY}`, { status }),
+        );
+      const fallbackFetch = vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(completionResponse(validCandidate()));
+      const provider = new TransportFallbackMultimodalJudgeProvider(
+        new HetznerMultimodalJudgeProvider(
+          {
+            provider: "openrouter",
+            baseUrl: "https://openrouter.example.test/api/v1",
+            apiKey: API_KEY,
+            model: "xiaomi/mimo-v2.5",
+            visionModel: "xiaomi/mimo-v2.5",
+          },
+          {
+            fetchImpl: primaryFetch,
+            policy: {
+              maxAttempts: 3,
+              attemptTimeoutMs: 100,
+              now: () => NOW.getTime(),
+              random: () => 0,
+              sleep: async () => undefined,
+            },
+          },
+        ),
+        new HetznerMultimodalJudgeProvider(
+          {
+            provider: "hetzner-inference",
+            baseUrl: "https://inference.example.test/api/v1",
+            apiKey: API_KEY,
+            model: "hetzner-judge",
+            visionModel: "hetzner-vision",
+          },
+          {
+            fetchImpl: fallbackFetch,
+            policy: {
+              maxAttempts: 3,
+              attemptTimeoutMs: 100,
+              now: () => NOW.getTime(),
+              random: () => 0,
+              sleep: async () => undefined,
+            },
+          },
+        ),
+      );
+
+      const result = await provider.evaluate(
+        { ...inputFixture(), frames: [] },
+        contextFixture(),
+      );
+
+      expect(primaryFetch).toHaveBeenCalledTimes(3);
+      expect(fallbackFetch).toHaveBeenCalledTimes(1);
+      expect(result.metadata).toMatchObject({
+        provider: "hetzner-inference",
+        model: "hetzner-judge",
+        outcome: "generated",
+      });
+      expect(JSON.stringify(result)).not.toContain(API_KEY);
+      expect(JSON.stringify(result)).not.toContain("private-body");
+    },
+  );
+
+  it("after the transport hop, HTTP 404 on the hop text model uses the hop vision model", async () => {
+    const primaryFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(null, { status: 408 }));
+    const fallbackFetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 404 }))
+      .mockResolvedValueOnce(completionResponse(validCandidate()));
+    const provider = new TransportFallbackMultimodalJudgeProvider(
+      new HetznerMultimodalJudgeProvider(
+        {
+          provider: "openrouter",
+          baseUrl: "https://openrouter.example.test/api/v1",
+          apiKey: API_KEY,
+          model: "xiaomi/mimo-v2.5",
+          visionModel: "xiaomi/mimo-v2.5",
+        },
+        {
+          fetchImpl: primaryFetch,
+          policy: {
+            maxAttempts: 3,
+            attemptTimeoutMs: 100,
+            now: () => NOW.getTime(),
+            random: () => 0,
+            sleep: async () => undefined,
+          },
+        },
+      ),
+      new HetznerMultimodalJudgeProvider(
+        {
+          provider: "hetzner-inference",
+          baseUrl: "https://inference.example.test/api/v1",
+          apiKey: API_KEY,
+          model: "hetzner-judge",
+          visionModel: "hetzner-vision",
+        },
+        {
+          fetchImpl: fallbackFetch,
+          policy: {
+            maxAttempts: 3,
+            attemptTimeoutMs: 100,
+            now: () => NOW.getTime(),
+            random: () => 0,
+            sleep: async () => undefined,
+          },
+        },
+      ),
+    );
+
+    const result = await provider.evaluate(inputFixture(), contextFixture());
+
+    expect(primaryFetch).toHaveBeenCalledTimes(3);
+    expect(fallbackFetch).toHaveBeenCalledTimes(2);
+    expect(
+      JSON.parse(String(fallbackFetch.mock.calls[0]?.[1]?.body)).model,
+    ).toBe("hetzner-judge");
+    expect(
+      JSON.parse(String(fallbackFetch.mock.calls[1]?.[1]?.body)).model,
+    ).toBe("hetzner-vision");
+    expect(result.metadata).toMatchObject({
+      provider: "hetzner-inference",
+      model: "hetzner-vision",
+      invocationCount: 2,
+      outcome: "repaired",
+    });
+  });
 
   it("hard-times out a fetch that ignores AbortSignal", async () => {
     const fetchImpl = vi.fn<typeof fetch>(

--- a/packages/providers/src/hetzner-multimodal.ts
+++ b/packages/providers/src/hetzner-multimodal.ts
@@ -1,7 +1,7 @@
 import { createHash } from "node:crypto";
 import { GitShaSchema, Sha256Schema, UuidSchema } from "@slopproof/domain";
 import { z } from "zod";
-import { ProviderError } from "./errors";
+import { ProviderError, isTransientUpstreamHttpStatus } from "./errors";
 import { ProviderContextV1Schema, type ProviderContextV1 } from "./contracts";
 
 const MAX_TRANSPORT_ATTEMPTS = 3;
@@ -12,6 +12,7 @@ const MAX_REQUEST_BYTES = 4 * 1_024 * 1_024;
 const MAX_MODEL_TEXT_BYTES = 512 * 1_024;
 const MAX_INLINE_FRAME_BYTES = 512 * 1_024;
 const MAX_INLINE_FRAME_TOTAL_BYTES = 2 * 1_024 * 1_024;
+const VISION_CAPABILITY_REJECTED_STATUSES = new Set([400, 404, 415, 422]);
 const timeoutMarker = Symbol("hetzner-multimodal-timeout");
 
 const SafeUntrustedTextV1Schema = z
@@ -992,11 +993,9 @@ async function requestJsonWithRetry(input: {
         }
         if (
           input.allowVisionCapabilityFallback &&
-          (error.status === 400 || error.status === 415 || error.status === 422)
+          VISION_CAPABILITY_REJECTED_STATUSES.has(error.status)
         ) {
           throw new VisionCapabilityRejectedError();
-        } else if (error.status === 408) {
-          lastFailure = { kind: "timeout" };
         } else if (error.status === 429) {
           lastFailure = {
             kind: "rate_limited",
@@ -1009,7 +1008,7 @@ async function requestJsonWithRetry(input: {
                   ),
                 }),
           };
-        } else if (error.status >= 500 && error.status <= 599) {
+        } else if (isTransientUpstreamHttpStatus(error.status)) {
           lastFailure = { kind: "unavailable" };
         } else {
           throw new ProviderError(

--- a/packages/providers/src/transport-fallback.test.ts
+++ b/packages/providers/src/transport-fallback.test.ts
@@ -345,6 +345,55 @@ describe("TransportFallbackMultimodalJudgeProvider", () => {
     );
   });
 
+  it.each([402, 404, 408])(
+    "hops the judge after a retryable HTTP %s transport failure",
+    async (httpStatus) => {
+      const primary = stubJudgeProvider(
+        {
+          provider: "openrouter",
+          model: "xiaomi/mimo-v2.5",
+          visionModel: "xiaomi/mimo-v2.5",
+        },
+        () => {
+          throw new ProviderError(
+            "PROVIDER_UNAVAILABLE",
+            "retryable",
+            "Multimodal provider is temporarily unavailable",
+            {
+              telemetry: {
+                lastFailureKind: "upstream_unavailable",
+                httpStatusClass: "4xx",
+                transportAttemptCount: 3,
+                httpStatus,
+              },
+            },
+          );
+        },
+      );
+      const fallback = stubJudgeProvider(
+        {
+          provider: "hetzner-inference",
+          model: "hetzner-judge",
+          visionModel: "hetzner-vision",
+        },
+        () =>
+          judgeResult({
+            provider: "hetzner-inference",
+            model: "hetzner-judge",
+          }),
+      );
+
+      const result = await new TransportFallbackMultimodalJudgeProvider(
+        primary,
+        fallback,
+      ).evaluate({} as MultimodalJudgeProviderInputV1, judgeContext());
+
+      expect(primary.evaluate).toHaveBeenCalledTimes(1);
+      expect(fallback.evaluate).toHaveBeenCalledTimes(1);
+      expect(result.metadata.model).toBe("hetzner-judge");
+    },
+  );
+
   it("does not hop the judge after INVALID_OUTPUT", async () => {
     const primary = stubJudgeProvider(
       {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Change

Two judge holes, one live and one hardening.

**This attempt (`0d33bf08`) did not die on empty frames.** The decrypted sidecar (metadata only) is `outcome=fallback`, `invocationCount=0`, `degraded=true`, `latencyMs=0`, `tokenUsage=null`, `frameWarnings=[]`, `candidate.warnings=["provider_evaluation_unavailable"]`. `frameWarnings=[]` means `loadNormalizedInlineJudgeFrames` succeeded. The empty-frames short-circuit never adds `provider_evaluation_unavailable`; that warning is only added after `evaluate()` throws. `evaluation.run` took 62.026s — 3×20s OpenRouter attempt timeouts plus hop. The hop ran. Then Hetzner failed fast.

The remaining miss is classification in `packages/providers/src/hetzner-multimodal.ts` `requestJsonWithRetry`:

- Generation (`hetzner-semantic.ts`) treats 402/404/408 as transient via `isTransientUpstreamHttpStatus` (PR 21), then hops.
- Judge only treated 408 as retryable. 402/404 were terminal `PROVIDER_UNAVAILABLE`, so `isTransportFailure` was false and `TransportFallbackMultimodalJudgeProvider` did not hop.
- Hop-model 400/404 also missed `VisionCapabilityRejectedError` (only 400/415/422, and 404 was terminal before that check could matter), so `JUDGE_TRANSPORT_FALLBACK_VISION_MODEL` (Qwen/Qwen3.6-35B-A3B-FP8) never ran. Live hop text model is Qwen3.8-27B.

This PR:

1. **Aligns judge HTTP retry with generation:** 402/404/408 are transient (retry, then hop via existing `TransportFallbackMultimodalJudgeProvider` / `isTransportFailure`). 401/403 stay terminal.
2. **Lets the hop vision model run:** if the hop text model rejects vision with 400/404/415/422 (same set as same-provider vision fallback), throw `VisionCapabilityRejectedError` so `JUDGE_TRANSPORT_FALLBACK_VISION_MODEL` is invoked.
3. **Keeps the empty-frame evaluate change as hardening.** Zero normalized frames still call `provider.evaluate` with the transcript. That is not why this attempt failed; it still closes a real product hole for future proofs.

Does not rewrite live attempt data. Does not merge. Does not deploy.

Left as-is: extractor `MAX_JPEG_BYTES` is 1MB while the judge loader and provider schema cap at 512KB. Irrelevant to this sidecar (`frameWarnings=[]`).

## Failure mode

- OpenRouter 402/404/408: retry on the primary, then hop to Hetzner. Exhausted transient errors stay retryable `PROVIDER_UNAVAILABLE` so the wrapper can hop.
- Hop text model 400/404/415/422 with frames and a distinct vision model: same-provider vision fallback runs. 402 on the hop text model still retries that model (payment/not-found-style transient), then fails closed if the hop is already the last provider.
- 401/403: still terminal, no retry, no hop, no vision fallback. No raw bodies or API keys leak.
- Deadline / hard input errors: still abort. Evaluate-throw (non-deadline) still becomes `manualReviewFallback` with `provider_evaluation_unavailable`.
- Empty frames: evaluate still runs on transcript; `frameWarnings` stay. Some frames: vision path / hop unchanged except for the HTTP classes above.

## Verification

- [x] Unit or contract tests (`pnpm test`: 827 passed — empty-frame evaluate, 402/404/408 retry+hop, hop-text 404 → hop vision, 401/403 terminal with and without frames)
- [ ] PostgreSQL integration tests when state or concurrency changed (none)
- [ ] Playwright coverage when a user flow changed (none)
- [ ] Threat model or provider data-flow update when a boundary changed (none)
- [x] `pnpm exec tsc --noEmit -p tsconfig.json`, eslint/prettier on the changed files
- [x] `pnpm audit:secrets`
- [x] No credentials, private repository data or evidence artifacts included
- [x] No review markdown in the public repo; rationale is this PR body only

## Privacy and public output

none

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71455f79-97dc-40c2-ae11-fbba5f59897a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71455f79-97dc-40c2-ae11-fbba5f59897a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

