### PR TITLE
fix: review playback without Content-Length and judge fallback telemetry

### DIFF
--- a/apps/web/app/api/review/[attemptId]/evidence-capability/route.ts
+++ b/apps/web/app/api/review/[attemptId]/evidence-capability/route.ts
@@ -18,6 +18,7 @@ import {
   ReviewAttemptIdSchema,
   reviewRouteErrorResponse,
 } from "../../../../../lib/review-http";
+import { logWebEvidenceStream } from "../../../../../lib/evidence-stream-log";
 import { getWebRuntime } from "../../../../../lib/runtime";
 import {
   consumeWebRequestRateLimit,
@@ -83,6 +84,11 @@ export async function POST(
       client.release();
     }
 
+    logWebEvidenceStream({
+      attemptId,
+      stage: "capability",
+      httpStatus: 200,
+    });
     const streamUrl = `/api/review/${attemptId}/evidence`;
     const response = NextResponse.json(
       { streamUrl, expiresAt: issued.payload.expiresAt },
@@ -97,6 +103,17 @@ export async function POST(
     });
     return response;
   } catch (error) {
+    const attemptId = await context.params
+      .then((params) => ReviewAttemptIdSchema.safeParse(params.attemptId).data)
+      .catch(() => undefined);
+    if (attemptId) {
+      logWebEvidenceStream({
+        attemptId,
+        stage: "capability",
+        errorClass: error instanceof Error ? error.name : "UnknownError",
+        ...(error instanceof InvalidRequestBodyError ? { httpStatus: 400 } : {}),
+      });
+    }
     if (error instanceof InvalidRequestBodyError) {
       return jsonError("invalid_request", 400);
     }

--- a/apps/web/app/api/review/[attemptId]/evidence/route.ts
+++ b/apps/web/app/api/review/[attemptId]/evidence/route.ts
@@ -24,6 +24,7 @@ import {
   consumeWebRequestRateLimit,
   createWebRequestSubjectHash,
 } from "../../../../../lib/request-rate-limit";
+import { logWebEvidenceStream } from "../../../../../lib/evidence-stream-log";
 import { getWebRuntime } from "../../../../../lib/runtime";
 
 export async function GET(
@@ -99,6 +100,19 @@ export async function GET(
       `${WORKER_REVIEW_EVIDENCE_PATH}/${encodeURIComponent(attemptId)}`,
       app.config.WORKER_INTERNAL_URL,
     );
+    const aborted = { value: false };
+    request.signal.addEventListener(
+      "abort",
+      () => {
+        aborted.value = true;
+        logWebEvidenceStream({
+          attemptId,
+          stage: "proxy",
+          aborted: true,
+        });
+      },
+      { once: true },
+    );
     const upstream = await fetch(workerUrl, {
       method: "GET",
       headers: { authorization: `Bearer ${token}` },
@@ -108,17 +122,33 @@ export async function GET(
     });
     if (upstream.status !== 200 || !upstream.body) {
       await upstream.body?.cancel();
-      return jsonError(
-        "evidence_unavailable",
-        upstream.status >= 500 ? 503 : 404,
-      );
+      const httpStatus = upstream.status >= 500 ? 503 : 404;
+      logWebEvidenceStream({
+        attemptId,
+        stage: "proxy",
+        httpStatus,
+        aborted: aborted.value,
+        contentTypePresent: Boolean(upstream.headers.get("content-type")),
+        contentLengthPresent: Boolean(upstream.headers.get("content-length")),
+        errorClass: "UpstreamUnavailable",
+      });
+      return jsonError("evidence_unavailable", httpStatus);
     }
     const contentType = upstream.headers.get("content-type")?.toLowerCase();
     if (!contentType?.startsWith("video/webm")) {
       await upstream.body.cancel();
+      logWebEvidenceStream({
+        attemptId,
+        stage: "proxy",
+        httpStatus: 503,
+        contentTypePresent: Boolean(contentType),
+        contentLengthPresent: Boolean(upstream.headers.get("content-length")),
+        errorClass: "InvalidContentType",
+      });
       return jsonError("evidence_unavailable", 503);
     }
 
+    const declaredLength = Number(upstream.headers.get("content-length"));
     const headers = new Headers({
       "cache-control": "private, no-store, max-age=0",
       "content-disposition": "inline",
@@ -128,6 +158,17 @@ export async function GET(
       const value = upstream.headers.get(name);
       if (value !== null) headers.set(name, value);
     }
+    logWebEvidenceStream({
+      attemptId,
+      stage: "proxy",
+      httpStatus: 200,
+      contentTypePresent: true,
+      contentLengthPresent: Number.isSafeInteger(declaredLength),
+      bytesExpected: Number.isSafeInteger(declaredLength)
+        ? declaredLength
+        : null,
+      aborted: aborted.value,
+    });
     const response = new NextResponse(upstream.body, {
       status: 200,
       headers,
@@ -141,6 +182,17 @@ export async function GET(
     });
     return response;
   } catch (error) {
+    const attemptId = await context.params
+      .then((params) => ReviewAttemptIdSchema.safeParse(params.attemptId).data)
+      .catch(() => undefined);
+    if (attemptId) {
+      logWebEvidenceStream({
+        attemptId,
+        stage: "proxy",
+        aborted: request.signal.aborted,
+        errorClass: error instanceof Error ? error.name : "UnknownError",
+      });
+    }
     return (
       reviewRouteErrorResponse(error) ?? jsonError("evidence_unavailable", 503)
     );

--- a/apps/web/app/review/[attemptId]/evidence-player.tsx
+++ b/apps/web/app/review/[attemptId]/evidence-player.tsx
@@ -1,7 +1,10 @@
 "use client";
 
-import { MAX_RECORDING_OBJECT_BYTES } from "@slopproof/media";
 import { useEffect, useRef, useState } from "react";
+import {
+  evidencePlaybackUserMessage,
+  loadReviewEvidencePlayback,
+} from "../../../lib/evidence-playback";
 
 type PlayerState =
   | { kind: "idle" }
@@ -27,58 +30,26 @@ export function EvidencePlayer({
   }, []);
 
   async function openEvidence(): Promise<void> {
-    const csrf = readCookie("slopproof_csrf");
-    if (!csrf) {
-      setState({ kind: "error", message: "The CSRF credential is missing." });
-      return;
-    }
     setState({ kind: "loading" });
     try {
-      const response = await fetch(
-        `/api/review/${attemptId}/evidence-capability`,
-        { method: "POST", headers: { "x-slopproof-csrf": csrf } },
-      );
-      const result = (await response.json().catch(() => null)) as {
-        streamUrl?: string;
-        expiresAt?: string;
-        error?: string;
-      } | null;
-      if (!response.ok || !result?.streamUrl || !result.expiresAt) {
-        throw new Error(result?.error ?? "Evidence access was rejected.");
-      }
-      const stream = await fetch(result.streamUrl, {
-        method: "GET",
-        cache: "no-store",
-        credentials: "same-origin",
+      const result = await loadReviewEvidencePlayback({
+        attemptId,
+        csrf: readCookie("slopproof_csrf"),
+        onEvent: (event) => {
+          console.info("slopproof.evidence.stream", event);
+        },
       });
-      const contentType = stream.headers.get("content-type")?.toLowerCase();
-      const contentLength = Number(stream.headers.get("content-length"));
-      if (
-        !stream.ok ||
-        !contentType?.startsWith("video/webm") ||
-        !Number.isSafeInteger(contentLength) ||
-        contentLength <= 0 ||
-        contentLength > MAX_RECORDING_OBJECT_BYTES
-      ) {
-        throw new Error("The evidence stream was rejected.");
-      }
-      const blob = await stream.blob();
-      if (blob.size !== contentLength) {
-        throw new Error("The evidence stream ended before its declared size.");
-      }
-      const objectUrl = URL.createObjectURL(blob);
       if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
-      objectUrlRef.current = objectUrl;
+      objectUrlRef.current = result.objectUrl;
       setState({
         kind: "ready",
-        streamUrl: objectUrl,
+        streamUrl: result.objectUrl,
         expiresAt: result.expiresAt,
       });
-    } catch {
+    } catch (error) {
       setState({
         kind: "error",
-        message:
-          "The video is not available. Request fresh access and try again.",
+        message: evidencePlaybackUserMessage(error),
       });
     }
   }

--- a/apps/web/lib/evidence-playback.test.ts
+++ b/apps/web/lib/evidence-playback.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  EvidencePlaybackError,
+  loadReviewEvidencePlayback,
+} from "./evidence-playback";
+
+const ATTEMPT_ID = "10000000-0000-4000-8000-000000000001";
+const WEBM = new Uint8Array([0x1a, 0x45, 0xdf, 0xa3, 0x01, 0x02, 0x03, 0x04]);
+
+describe("review evidence playback", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("plays a valid WebM body when Content-Length is missing", async () => {
+    const objectUrl = "blob:evidence-missing-length";
+    vi.stubGlobal(
+      "URL",
+      {
+        ...URL,
+        createObjectURL: vi.fn(() => objectUrl),
+        revokeObjectURL: vi.fn(),
+      } as unknown as typeof URL,
+    );
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          streamUrl: `/api/review/${ATTEMPT_ID}/evidence`,
+          expiresAt: "2026-08-21T14:30:00.000Z",
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(WEBM, {
+          status: 200,
+          headers: { "content-type": "video/webm" },
+        }),
+      );
+
+    const result = await loadReviewEvidencePlayback({
+      attemptId: ATTEMPT_ID,
+      csrf: "csrf-token",
+      fetchImpl,
+    });
+
+    expect(result).toEqual({
+      objectUrl,
+      expiresAt: "2026-08-21T14:30:00.000Z",
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries an aborted transfer with a fresh capability and then plays", async () => {
+    const objectUrl = "blob:evidence-after-retry";
+    vi.stubGlobal(
+      "URL",
+      {
+        ...URL,
+        createObjectURL: vi.fn(() => objectUrl),
+        revokeObjectURL: vi.fn(),
+      } as unknown as typeof URL,
+    );
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          streamUrl: `/api/review/${ATTEMPT_ID}/evidence`,
+          expiresAt: "2026-08-21T14:30:00.000Z",
+        }),
+      )
+      .mockRejectedValueOnce(
+        Object.assign(new Error("The user aborted a request."), {
+          name: "AbortError",
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          streamUrl: `/api/review/${ATTEMPT_ID}/evidence`,
+          expiresAt: "2026-08-21T14:31:00.000Z",
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(WEBM, {
+          status: 200,
+          headers: {
+            "content-type": "video/webm",
+            "content-length": String(WEBM.byteLength),
+          },
+        }),
+      );
+
+    const events: Array<{ stage: string; aborted: boolean }> = [];
+    const result = await loadReviewEvidencePlayback({
+      attemptId: ATTEMPT_ID,
+      csrf: "csrf-token",
+      fetchImpl,
+      onEvent: (event) => {
+        events.push({ stage: event.stage, aborted: event.aborted });
+      },
+    });
+
+    expect(result.objectUrl).toBe(objectUrl);
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+    expect(events.some((event) => event.aborted)).toBe(true);
+  });
+
+  it("reports a retryable message after an incomplete Content-Length mismatch", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        jsonResponse({
+          streamUrl: `/api/review/${ATTEMPT_ID}/evidence`,
+          expiresAt: "2026-08-21T14:30:00.000Z",
+        }),
+      )
+      .mockResolvedValue(
+        new Response(WEBM, {
+          status: 200,
+          headers: {
+            "content-type": "video/webm",
+            "content-length": "11301489",
+          },
+        }),
+      );
+    fetchImpl
+      .mockReset()
+      .mockImplementation(async (url) => {
+        if (String(url).includes("evidence-capability")) {
+          return jsonResponse({
+            streamUrl: `/api/review/${ATTEMPT_ID}/evidence`,
+            expiresAt: "2026-08-21T14:30:00.000Z",
+          });
+        }
+        return new Response(WEBM, {
+          status: 200,
+          headers: {
+            "content-type": "video/webm",
+            "content-length": "11301489",
+          },
+        });
+      });
+
+    await expect(
+      loadReviewEvidencePlayback({
+        attemptId: ATTEMPT_ID,
+        csrf: "csrf-token",
+        fetchImpl,
+        maxAutomaticRetries: 1,
+      }),
+    ).rejects.toMatchObject({
+      code: "transfer_incomplete",
+      retryable: true,
+      message:
+        "The recording transfer was interrupted. Request fresh access and try again.",
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+  });
+
+  it("keeps a matching Content-Length success path unchanged", async () => {
+    const objectUrl = "blob:evidence-success";
+    vi.stubGlobal(
+      "URL",
+      {
+        ...URL,
+        createObjectURL: vi.fn(() => objectUrl),
+        revokeObjectURL: vi.fn(),
+      } as unknown as typeof URL,
+    );
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          streamUrl: `/api/review/${ATTEMPT_ID}/evidence`,
+          expiresAt: "2026-08-21T14:30:00.000Z",
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(WEBM, {
+          status: 200,
+          headers: {
+            "content-type": "video/webm",
+            "content-length": String(WEBM.byteLength),
+          },
+        }),
+      );
+
+    await expect(
+      loadReviewEvidencePlayback({
+        attemptId: ATTEMPT_ID,
+        csrf: "csrf-token",
+        fetchImpl,
+      }),
+    ).resolves.toEqual({
+      objectUrl,
+      expiresAt: "2026-08-21T14:30:00.000Z",
+    });
+  });
+
+  it("does not retry a missing CSRF credential", async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    await expect(
+      loadReviewEvidencePlayback({
+        attemptId: ATTEMPT_ID,
+        csrf: undefined,
+        fetchImpl,
+      }),
+    ).rejects.toBeInstanceOf(EvidencePlaybackError);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/apps/web/lib/evidence-playback.ts
+++ b/apps/web/lib/evidence-playback.ts
@@ -1,0 +1,240 @@
+import { MAX_RECORDING_OBJECT_BYTES } from "@slopproof/media";
+
+export const EVIDENCE_PLAYBACK_AUTOMATIC_RETRIES = 2;
+
+export type EvidencePlaybackEvent = {
+  attemptId: string;
+  stage: "capability" | "client";
+  bytesExpected: number | null;
+  bytesReceived: number | null;
+  contentTypePresent: boolean;
+  contentLengthPresent: boolean;
+  aborted: boolean;
+  httpStatus: number | null;
+  retry: number;
+};
+
+export type EvidencePlaybackErrorCode =
+  | "csrf_missing"
+  | "capability_rejected"
+  | "stream_rejected"
+  | "transfer_incomplete"
+  | "unavailable";
+
+export class EvidencePlaybackError extends Error {
+  readonly retryable: boolean;
+
+  constructor(
+    readonly code: EvidencePlaybackErrorCode,
+    message: string,
+    retryable: boolean,
+  ) {
+    super(message);
+    this.name = "EvidencePlaybackError";
+    this.retryable = retryable;
+  }
+}
+
+export type EvidencePlaybackResult = {
+  objectUrl: string;
+  expiresAt: string;
+};
+
+export async function loadReviewEvidencePlayback(input: {
+  attemptId: string;
+  csrf: string | undefined;
+  fetchImpl?: typeof fetch;
+  maxAutomaticRetries?: number;
+  onEvent?: (event: EvidencePlaybackEvent) => void;
+}): Promise<EvidencePlaybackResult> {
+  if (!input.csrf) {
+    throw new EvidencePlaybackError(
+      "csrf_missing",
+      "The CSRF credential is missing.",
+      false,
+    );
+  }
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const maxAutomaticRetries =
+    input.maxAutomaticRetries ?? EVIDENCE_PLAYBACK_AUTOMATIC_RETRIES;
+  let lastError: EvidencePlaybackError | undefined;
+  for (let retry = 0; retry <= maxAutomaticRetries; retry += 1) {
+    try {
+      return await attemptEvidencePlayback({
+        attemptId: input.attemptId,
+        csrf: input.csrf,
+        fetchImpl,
+        retry,
+        ...(input.onEvent === undefined ? {} : { onEvent: input.onEvent }),
+      });
+    } catch (error) {
+      lastError = asPlaybackError(error);
+      if (!lastError.retryable || retry === maxAutomaticRetries) {
+        throw lastError;
+      }
+    }
+  }
+  throw (
+    lastError ??
+    new EvidencePlaybackError(
+      "unavailable",
+      "The video is not available. Request fresh access and try again.",
+      false,
+    )
+  );
+}
+
+async function attemptEvidencePlayback(input: {
+  attemptId: string;
+  csrf: string;
+  fetchImpl: typeof fetch;
+  retry: number;
+  onEvent?: (event: EvidencePlaybackEvent) => void;
+}): Promise<EvidencePlaybackResult> {
+  const emit = (
+    stage: EvidencePlaybackEvent["stage"],
+    fields: Partial<EvidencePlaybackEvent>,
+  ): void => {
+    input.onEvent?.({
+      attemptId: input.attemptId,
+      stage,
+      bytesExpected: null,
+      bytesReceived: null,
+      contentTypePresent: false,
+      contentLengthPresent: false,
+      aborted: false,
+      httpStatus: null,
+      retry: input.retry,
+      ...fields,
+    });
+  };
+
+  let capabilityStatus: number | null = null;
+  try {
+    const response = await input.fetchImpl(
+      `/api/review/${input.attemptId}/evidence-capability`,
+      { method: "POST", headers: { "x-slopproof-csrf": input.csrf } },
+    );
+    capabilityStatus = response.status;
+    const result = (await response.json().catch(() => null)) as {
+      streamUrl?: string;
+      expiresAt?: string;
+      error?: string;
+    } | null;
+    emit("capability", {
+      httpStatus: capabilityStatus,
+      contentTypePresent: response.headers.has("content-type"),
+    });
+    if (!response.ok || !result?.streamUrl || !result.expiresAt) {
+      throw new EvidencePlaybackError(
+        "capability_rejected",
+        result?.error ?? "Evidence access was rejected.",
+        response.status >= 500,
+      );
+    }
+
+    const stream = await input.fetchImpl(result.streamUrl, {
+      method: "GET",
+      cache: "no-store",
+      credentials: "same-origin",
+    });
+    const contentType = stream.headers.get("content-type")?.toLowerCase();
+    const declaredLength = parseDeclaredLength(
+      stream.headers.get("content-length"),
+    );
+    emit("client", {
+      httpStatus: stream.status,
+      contentTypePresent: Boolean(contentType),
+      contentLengthPresent: declaredLength !== undefined,
+      bytesExpected: declaredLength ?? null,
+    });
+    if (!stream.ok) {
+      throw new EvidencePlaybackError(
+        "stream_rejected",
+        "The evidence stream was rejected.",
+        stream.status >= 500 || stream.status === 404,
+      );
+    }
+    if (!contentType?.startsWith("video/webm")) {
+      await stream.body?.cancel();
+      throw new EvidencePlaybackError(
+        "stream_rejected",
+        "The evidence stream was rejected.",
+        false,
+      );
+    }
+    if (
+      declaredLength !== undefined &&
+      (declaredLength <= 0 || declaredLength > MAX_RECORDING_OBJECT_BYTES)
+    ) {
+      await stream.body?.cancel();
+      throw new EvidencePlaybackError(
+        "stream_rejected",
+        "The evidence stream was rejected.",
+        false,
+      );
+    }
+
+    const blob = await stream.blob();
+    emit("client", {
+      httpStatus: stream.status,
+      contentTypePresent: true,
+      contentLengthPresent: declaredLength !== undefined,
+      bytesExpected: declaredLength ?? null,
+      bytesReceived: blob.size,
+    });
+    if (
+      blob.size <= 0 ||
+      blob.size > MAX_RECORDING_OBJECT_BYTES ||
+      (declaredLength !== undefined && blob.size !== declaredLength)
+    ) {
+      throw new EvidencePlaybackError(
+        "transfer_incomplete",
+        "The recording transfer was interrupted. Request fresh access and try again.",
+        true,
+      );
+    }
+    return {
+      objectUrl: URL.createObjectURL(blob),
+      expiresAt: result.expiresAt,
+    };
+  } catch (error) {
+    if (error instanceof EvidencePlaybackError) throw error;
+    emit("client", {
+      httpStatus: capabilityStatus,
+      aborted: isAbortLike(error),
+    });
+    throw new EvidencePlaybackError(
+      "transfer_incomplete",
+      "The recording transfer was interrupted. Request fresh access and try again.",
+      true,
+    );
+  }
+}
+
+function parseDeclaredLength(raw: string | null): number | undefined {
+  if (raw === null || raw.trim() === "") return undefined;
+  const value = Number(raw);
+  return Number.isSafeInteger(value) ? value : undefined;
+}
+
+function asPlaybackError(error: unknown): EvidencePlaybackError {
+  return error instanceof EvidencePlaybackError
+    ? error
+    : new EvidencePlaybackError(
+        "unavailable",
+        "The video is not available. Request fresh access and try again.",
+        false,
+      );
+}
+
+function isAbortLike(error: unknown): boolean {
+  if (error instanceof DOMException && error.name === "AbortError") return true;
+  if (error instanceof Error && error.name === "AbortError") return true;
+  return false;
+}
+
+export function evidencePlaybackUserMessage(error: unknown): string {
+  if (error instanceof EvidencePlaybackError) return error.message;
+  return "The video is not available. Request fresh access and try again.";
+}

--- a/apps/web/lib/evidence-stream-log.test.ts
+++ b/apps/web/lib/evidence-stream-log.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { logWebEvidenceStream } from "./evidence-stream-log";
+import { setWebLoggerForTests } from "./web-log";
+
+describe("web evidence stream logs", () => {
+  afterEach(() => {
+    setWebLoggerForTests(undefined);
+  });
+
+  it("writes attemptId and stage without cookies, tokens, or keys", () => {
+    const info = vi.fn();
+    setWebLoggerForTests({ info } as never);
+    logWebEvidenceStream({
+      attemptId: "10000000-0000-4000-8000-000000000001",
+      stage: "proxy",
+      httpStatus: 200,
+      contentTypePresent: true,
+      contentLengthPresent: false,
+      bytesExpected: null,
+      aborted: false,
+    });
+    expect(info).toHaveBeenCalledWith(
+      {
+        attemptId: "10000000-0000-4000-8000-000000000001",
+        stage: "proxy",
+        bytesExpected: null,
+        contentTypePresent: true,
+        contentLengthPresent: false,
+        aborted: false,
+        httpStatus: 200,
+      },
+      "web.evidence.stream",
+    );
+    expect(JSON.stringify(info.mock.calls)).not.toContain("cookie");
+    expect(JSON.stringify(info.mock.calls)).not.toContain("Bearer");
+    expect(JSON.stringify(info.mock.calls)).not.toContain("wrapped");
+  });
+});

--- a/apps/web/lib/evidence-stream-log.ts
+++ b/apps/web/lib/evidence-stream-log.ts
@@ -1,0 +1,34 @@
+import { getWebLogger } from "./web-log";
+
+export type WebEvidenceStreamStage = "capability" | "proxy";
+
+export function logWebEvidenceStream(fields: {
+  attemptId: string;
+  stage: WebEvidenceStreamStage;
+  bytesExpected?: number | null;
+  contentTypePresent?: boolean;
+  contentLengthPresent?: boolean;
+  aborted?: boolean;
+  httpStatus?: number;
+  errorClass?: string;
+}): void {
+  getWebLogger().info(
+    {
+      attemptId: fields.attemptId,
+      stage: fields.stage,
+      ...(fields.bytesExpected === undefined
+        ? {}
+        : { bytesExpected: fields.bytesExpected }),
+      ...(fields.contentTypePresent === undefined
+        ? {}
+        : { contentTypePresent: fields.contentTypePresent }),
+      ...(fields.contentLengthPresent === undefined
+        ? {}
+        : { contentLengthPresent: fields.contentLengthPresent }),
+      ...(fields.aborted === undefined ? {} : { aborted: fields.aborted }),
+      ...(fields.httpStatus === undefined ? {} : { httpStatus: fields.httpStatus }),
+      ...(fields.errorClass === undefined ? {} : { errorClass: fields.errorClass }),
+    },
+    "web.evidence.stream",
+  );
+}

--- a/apps/web/lib/web-log.ts
+++ b/apps/web/lib/web-log.ts
@@ -1,0 +1,15 @@
+import { createLogger, type Logger } from "@slopproof/observability";
+
+let logger: Logger | undefined;
+
+export function getWebLogger(): Logger {
+  logger ??= createLogger(
+    { service: "web", version: "0.1.0" },
+    process.env.LOG_LEVEL ?? "info",
+  );
+  return logger;
+}
+
+export function setWebLoggerForTests(value: Logger | undefined): void {
+  logger = value;
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -146,6 +146,9 @@ async function handleHttpRequest(
       storage,
       privateKeyPath,
       capabilitySecret: config.WORKER_INTERNAL_SECRET,
+      onEvent: (event) => {
+        log.info(event, "worker.evidence.stream");
+      },
       onFailure: (failure) => {
         log.warn(failure, "worker.review_evidence_failed");
       },
@@ -315,6 +318,7 @@ async function start(): Promise<void> {
   await registerProviderPipelineWorkers(activeJobQueue, {
     repository: providerPipelineRepository,
     payloadCipher: activePayloadCipher,
+    log,
     ...createTranscriptionPipelineSelection(config, {
       privateKeyPath: activePrivateKeyPath,
       storage,

--- a/apps/worker/src/multimodal-judge-service.test.ts
+++ b/apps/worker/src/multimodal-judge-service.test.ts
@@ -1,5 +1,6 @@
 import {
   ProofEvaluationInputV1Schema,
+  ProviderError,
   multimodalJudgeCandidateHashV1,
   multimodalJudgeProviderInputHashV1,
   type InlineMultimodalJudgeProvider,
@@ -160,9 +161,16 @@ describe("multimodal judge service", () => {
     });
     expect(result.invocationMetadata).toMatchObject({
       outcome: "fallback",
-      invocationCount: 0,
+      invocationCount: 1,
       degraded: true,
+      failureDiagnostics: {
+        errorClass: "Error",
+        hopUsed: "none",
+        invocationCount: 1,
+        frameCount: 0,
+      },
     });
+    expect(result.frameCount).toBe(0);
     expect(JSON.stringify(result)).not.toContain("private raw provider");
   });
 
@@ -253,6 +261,105 @@ describe("multimodal judge service", () => {
     });
     expect(JSON.stringify(result)).not.toContain("private raw provider");
     expect(frameBytes).toEqual(new Uint8Array(4));
+  });
+
+  it("persists httpStatus, hopUsed, and invocation count when evaluate throws a mocked 404", async () => {
+    const provider: InlineMultimodalJudgeProvider = {
+      descriptor: descriptorFixture(),
+      transportFallbackDescriptor: {
+        provider: "hetzner-inference",
+        model: "hetzner-judge",
+        visionModel: "hetzner-vision",
+      },
+      evaluate: vi.fn(async () => {
+        throw new ProviderError(
+          "PROVIDER_UNAVAILABLE",
+          "retryable",
+          "Multimodal provider is temporarily unavailable",
+          {
+            hopUsed: "transport_fallback",
+            telemetry: {
+              lastFailureKind: "upstream_unavailable",
+              httpStatusClass: "4xx",
+              transportAttemptCount: 3,
+              httpStatus: 404,
+            },
+          },
+        );
+      }),
+    };
+    const result = await runMultimodalJudgeEvaluation(
+      inputFixture(),
+      contextFixture(),
+      {
+        provider,
+        loadFrames: vi.fn(async () => ({
+          frames: [frameFixture()],
+          warnings: [],
+        })),
+        now: () => NOW,
+      },
+    );
+    expect(result.invocationMetadata).toMatchObject({
+      outcome: "fallback",
+      invocationCount: 2,
+      latencyMs: 0,
+      failureDiagnostics: {
+        httpStatus: 404,
+        errorClass: "ProviderError",
+        errorCode: "PROVIDER_UNAVAILABLE",
+        disposition: "retryable",
+        lastFailureKind: "upstream_unavailable",
+        hopUsed: "transport_fallback",
+        invocationCount: 2,
+        frameCount: 1,
+      },
+    });
+    expect(result.frameCount).toBe(1);
+    expect(result.frameWarnings).toEqual([]);
+  });
+
+  it("records a network evaluate failure without logging the provider payload", async () => {
+    const provider: InlineMultimodalJudgeProvider = {
+      descriptor: descriptorFixture(),
+      evaluate: vi.fn(async () => {
+        throw new ProviderError(
+          "PROVIDER_UNAVAILABLE",
+          "retryable",
+          "Multimodal provider is temporarily unavailable",
+          {
+            telemetry: {
+              lastFailureKind: "network",
+              httpStatusClass: null,
+              transportAttemptCount: 1,
+            },
+          },
+        );
+      }),
+    };
+    const result = await runMultimodalJudgeEvaluation(
+      inputFixture(),
+      contextFixture(),
+      {
+        provider,
+        loadFrames: vi.fn(async () => ({
+          frames: [frameFixture()],
+          warnings: [],
+        })),
+        now: () => NOW,
+      },
+    );
+    expect(result.invocationMetadata.failureDiagnostics).toMatchObject({
+      errorCode: "PROVIDER_UNAVAILABLE",
+      lastFailureKind: "network",
+      hopUsed: "none",
+      invocationCount: 1,
+      frameCount: 1,
+    });
+    expect(result.invocationMetadata.failureDiagnostics).not.toHaveProperty(
+      "httpStatus",
+    );
+    expect(JSON.stringify(result)).not.toContain("temporarily unavailable");
   });
 
   it("persists no late provider result and wipes frames when provider work crosses the deadline", async () => {

--- a/apps/worker/src/multimodal-judge-service.ts
+++ b/apps/worker/src/multimodal-judge-service.ts
@@ -11,6 +11,7 @@ import {
   ProofEvaluationInputV1Schema,
   ProviderContextV1Schema,
   ProviderError,
+  describeJudgeEvaluateFailure,
   manualReviewFallbackMultimodalJudgeResultV1,
   validateMultimodalJudgeProviderResultV1,
   type InlineMultimodalJudgeProvider,
@@ -110,9 +111,10 @@ export async function runMultimodalJudgeEvaluation(
       loadedFrames.frames,
     );
     let providerResult;
+    const evaluateStartedAt = now();
     try {
       providerResult = validateMultimodalJudgeProviderResultV1(
-        await runUntilMultimodalDeadline(context.data, now(), () =>
+        await runUntilMultimodalDeadline(context.data, evaluateStartedAt, () =>
           dependencies.provider.evaluate(providerInput, context.data),
         ),
         providerInput,
@@ -131,11 +133,20 @@ export async function runMultimodalJudgeEvaluation(
       );
     } catch (error) {
       if (isMultimodalDeadlineError(error)) throw multimodalDeadlineError();
+      const completedAt = now();
       providerResult = manualReviewFallbackMultimodalJudgeResultV1(
         providerInput,
         dependencies.provider.descriptor,
         [...frameWarnings, "provider_evaluation_unavailable"],
-        now(),
+        completedAt,
+        describeJudgeEvaluateFailure(error, {
+          hopUsed:
+            dependencies.provider.transportFallbackDescriptor === undefined
+              ? "none"
+              : "primary",
+          latencyMs: completedAt.getTime() - evaluateStartedAt.getTime(),
+          frameCount: loadedFrames.frames.length,
+        }),
       );
     }
     const completedAt = now();
@@ -155,6 +166,7 @@ export async function runMultimodalJudgeEvaluation(
       candidate: providerResult.candidate,
       invocationMetadata: providerResult.metadata,
       frameWarnings,
+      frameCount: loadedFrames.frames.length,
       workflowOutcome: "review_required",
       manualReviewRequired: true,
       createdAt: completedAt,

--- a/apps/worker/src/provider-pipeline-contracts.ts
+++ b/apps/worker/src/provider-pipeline-contracts.ts
@@ -16,6 +16,9 @@ import {
 } from "@slopproof/policy";
 import {
   FrameSelectionMetadataV1Schema,
+  JudgeHopUsedSchema,
+  PROVIDER_ERROR_CODES,
+  PROVIDER_FAILURE_KINDS,
   type ProviderErrorCode,
   type ProviderFailureTelemetry,
 } from "@slopproof/providers";
@@ -193,6 +196,26 @@ export const ProviderPipelineStageResultV1Schema = z
     ]),
     attemptId: UuidSchema,
     artifactId: UuidSchema.optional(),
+    judge: z
+      .object({
+        outcome: z.enum(["generated", "repaired", "fallback"]),
+        hopUsed: JudgeHopUsedSchema.optional(),
+        httpStatus: z.number().int().min(100).max(599).optional(),
+        errorClass: z.enum(["ProviderError", "Error", "UnknownError"]).optional(),
+        errorCode: z.enum(PROVIDER_ERROR_CODES).optional(),
+        disposition: z.enum(["retryable", "terminal", "review"]).optional(),
+        lastFailureKind: z.enum(PROVIDER_FAILURE_KINDS).optional(),
+        invocationCount: z.union([z.literal(0), z.literal(1), z.literal(2)]),
+        latencyMs: z
+          .number()
+          .int()
+          .nonnegative()
+          .max(15 * 60_000),
+        frameCount: z.number().int().nonnegative().max(32),
+        frameWarnings: z.array(z.string().max(80)).max(10),
+      })
+      .strict()
+      .optional(),
   })
   .strict();
 

--- a/apps/worker/src/provider-pipeline.test.ts
+++ b/apps/worker/src/provider-pipeline.test.ts
@@ -1461,6 +1461,113 @@ describe("provider worker pipeline", () => {
     );
   });
 
+  it("records fallback judge enums on evaluation.run job output and info logs", async () => {
+    const base = fixture();
+    await base.handlers.extractTranscript(extractJob);
+    base.dispatcher.jobs.length = 0;
+    const sidecars = new InMemoryMultimodalEvaluationRepository();
+    const provider: InlineMultimodalJudgeProvider = {
+      descriptor: {
+        provider: "openrouter",
+        model: "xiaomi/mimo-v2.5",
+        visionModel: "xiaomi/mimo-v2.5",
+      },
+      transportFallbackDescriptor: {
+        provider: "hetzner-inference",
+        model: "hetzner-judge",
+        visionModel: "hetzner-vision",
+      },
+      evaluate: vi.fn(async () => {
+        throw new ProviderError(
+          "PROVIDER_UNAVAILABLE",
+          "retryable",
+          "private raw provider payload and API key",
+          {
+            hopUsed: "transport_fallback",
+            telemetry: {
+              lastFailureKind: "upstream_unavailable",
+              httpStatusClass: "4xx",
+              transportAttemptCount: 3,
+              httpStatus: 402,
+            },
+          },
+        );
+      }),
+    };
+    const info = vi.fn();
+    const evaluate = vi.fn(
+      (
+        input: Parameters<typeof runMultimodalJudgeEvaluation>[0],
+        context: Parameters<typeof runMultimodalJudgeEvaluation>[1],
+        dependencies: Parameters<typeof runMultimodalJudgeEvaluation>[2],
+      ) =>
+        runMultimodalJudgeEvaluation(input, context, {
+          ...dependencies,
+          loadFrames: vi.fn(async () => ({
+            frames: [gate6InlineFrameFixture()],
+            warnings: [],
+          })),
+        }),
+    );
+    const handlers = createProviderPipelineHandlers({
+      repository: base.repository,
+      dispatcher: base.dispatcher,
+      payloadCipher: base.payloadCipher,
+      transcriptionProvider: new LocalFakeTranscriptionProvider({
+        now: () => NOW,
+      }),
+      frameSelectionAdapter: new OneFrameAdapter(),
+      judgeProvider: createGate5MultimodalJudgeBoundary("hetzner", {
+        now: () => NOW,
+      }),
+      multimodalJudge: {
+        provider,
+        repository: sidecars,
+        frameStorage: { getObjectStream: vi.fn() },
+        evaluate,
+      },
+      clock: { now: () => NOW },
+      log: { info },
+    });
+
+    const outcome = await handlers.runEvaluation(
+      gate6EvaluationJob(base.repository.transcript!.transcriptId),
+    );
+
+    expect(outcome).toMatchObject({
+      stage: "evaluation.run",
+      outcome: "completed",
+      judge: {
+        outcome: "fallback",
+        hopUsed: "transport_fallback",
+        httpStatus: 402,
+        errorClass: "ProviderError",
+        errorCode: "PROVIDER_UNAVAILABLE",
+        disposition: "retryable",
+        lastFailureKind: "upstream_unavailable",
+        invocationCount: 2,
+        frameCount: 1,
+        frameWarnings: [],
+      },
+    });
+    expect(info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stage: "evaluation.run",
+        hopUsed: "transport_fallback",
+        httpStatus: 402,
+        errorCode: "PROVIDER_UNAVAILABLE",
+        invocationCount: 2,
+        frameCount: 1,
+      }),
+      "worker.evaluation.run",
+    );
+    expect(JSON.stringify(info.mock.calls)).not.toContain("private raw provider");
+    expect(JSON.stringify(info.mock.calls)).not.toContain("API key");
+    expect(
+      JSON.stringify(sidecars.persisted?.multimodalEvaluation),
+    ).not.toContain("private raw provider");
+  });
+
   it("strictly rejects unknown job data before external effects", async () => {
     const base = fixture();
     await expect(

--- a/apps/worker/src/provider-pipeline.ts
+++ b/apps/worker/src/provider-pipeline.ts
@@ -26,6 +26,7 @@ import {
   type ProofEvaluationV1,
   type TranscriptV1,
   type TranscriptionProvider,
+  type JudgeHopUsed,
 } from "@slopproof/providers";
 import type { PgBoss } from "pg-boss";
 import { z } from "zod";
@@ -127,6 +128,9 @@ export type ProviderPipelineDependencies = {
   clock: ProviderClock;
   providerTimeoutMs?: number;
   fakeTranscriptText?: (question: StoredProofQuestionV1) => string;
+  log?: {
+    info(fields: Record<string, unknown>, message: string): void;
+  };
 };
 
 export type ProviderPipelineHandlers = {
@@ -435,11 +439,79 @@ function result(input: {
   outcome: ProviderPipelineStageResultV1["outcome"];
   attemptId: string;
   artifactId?: string;
+  judge?: ProviderPipelineStageResultV1["judge"];
 }): ProviderPipelineStageResultV1 {
   return ProviderPipelineStageResultV1Schema.parse({
     schemaVersion: "1",
     ...input,
   });
+}
+
+function judgeJobDiagnostics(
+  evaluation: MultimodalProofEvaluationV1,
+  provider: InlineMultimodalJudgeProvider,
+): NonNullable<ProviderPipelineStageResultV1["judge"]> {
+  const metadata = evaluation.invocationMetadata;
+  const failure = metadata.failureDiagnostics;
+  return {
+    outcome: metadata.outcome,
+    hopUsed:
+      failure?.hopUsed ?? hopUsedFromSuccessfulMetadata(provider, metadata),
+    ...(failure?.httpStatus === undefined
+      ? {}
+      : { httpStatus: failure.httpStatus }),
+    ...(failure?.errorClass === undefined
+      ? {}
+      : { errorClass: failure.errorClass }),
+    ...(failure?.errorCode === undefined ? {} : { errorCode: failure.errorCode }),
+    ...(failure?.disposition === undefined
+      ? {}
+      : { disposition: failure.disposition }),
+    ...(failure?.lastFailureKind === undefined
+      ? {}
+      : { lastFailureKind: failure.lastFailureKind }),
+    invocationCount: metadata.invocationCount,
+    latencyMs: metadata.latencyMs,
+    frameCount: evaluation.frameCount ?? failure?.frameCount ?? 0,
+    frameWarnings: [...evaluation.frameWarnings],
+  };
+}
+
+function hopUsedFromSuccessfulMetadata(
+  provider: InlineMultimodalJudgeProvider,
+  metadata: MultimodalProofEvaluationV1["invocationMetadata"],
+): JudgeHopUsed {
+  const fallback = provider.transportFallbackDescriptor;
+  if (
+    fallback &&
+    metadata.provider === fallback.provider &&
+    (metadata.model === fallback.model ||
+      metadata.model === fallback.visionModel)
+  ) {
+    return "transport_fallback";
+  }
+  if (
+    metadata.provider === provider.descriptor.provider &&
+    (metadata.model === provider.descriptor.model ||
+      metadata.model === provider.descriptor.visionModel)
+  ) {
+    return "primary";
+  }
+  return "none";
+}
+
+function evaluationRunLogFields(
+  stageResult: ProviderPipelineStageResultV1,
+): Record<string, unknown> {
+  return {
+    attemptId: stageResult.attemptId,
+    stage: stageResult.stage,
+    outcome: stageResult.outcome,
+    ...(stageResult.artifactId === undefined
+      ? {}
+      : { artifactId: stageResult.artifactId }),
+    ...(stageResult.judge === undefined ? {} : stageResult.judge),
+  };
 }
 
 async function routeProviderFailure(
@@ -1081,13 +1153,22 @@ export function createProviderPipelineHandlers(
               evaluationId: persistence.compatibilityEvaluation.evaluationId,
             });
           }
-          return result({
+          const stageResult = result({
             stage: "evaluation.run",
             outcome:
               persistence.status === "created" ? "completed" : "replayed",
             attemptId: job.attemptId,
             artifactId: persistence.compatibilityEvaluation.evaluationId,
+            judge: judgeJobDiagnostics(
+              multimodalEvaluation,
+              dependencies.multimodalJudge.provider,
+            ),
           });
+          dependencies.log?.info(
+            evaluationRunLogFields(stageResult),
+            "worker.evaluation.run",
+          );
+          return stageResult;
         }
         if (dependencies.judgeProvider === undefined) {
           throw new ProviderError(
@@ -1321,7 +1402,9 @@ export type ProviderPipelineRegistrationDependencies = Omit<
 
 export async function registerProviderPipelineWorkers(
   queue: PgBoss,
-  dependencies: ProviderPipelineRegistrationDependencies,
+  dependencies: ProviderPipelineRegistrationDependencies & {
+    log?: ProviderPipelineDependencies["log"];
+  },
 ): Promise<{
   extractTranscriptWorkerId: string;
   selectFramesWorkerId: string;

--- a/apps/worker/src/review-stream.test.ts
+++ b/apps/worker/src/review-stream.test.ts
@@ -10,7 +10,7 @@ import {
 const ATTEMPT_ID = "53000000-0000-4000-8000-000000000001";
 
 describe("private review stream failures", () => {
-  it("reports only a fixed stage and error class, never the attempt identifier", async () => {
+  it("reports attemptId, stage, and error class without capability secrets", async () => {
     const failure = vi.fn<(value: ReviewStreamFailure) => void>();
     const output = responseFixture();
 
@@ -33,11 +33,18 @@ describe("private review stream failures", () => {
     ).resolves.toBe(true);
 
     expect(failure).toHaveBeenCalledOnce();
-    expect(failure).toHaveBeenCalledWith({
-      stage: "capability",
-      errorClass: "Error",
-    });
-    expect(JSON.stringify(failure.mock.calls)).not.toContain(ATTEMPT_ID);
+    expect(failure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attemptId: ATTEMPT_ID,
+        stage: "capability",
+        errorClass: "Error",
+        httpStatus: 401,
+      }),
+    );
+    expect(JSON.stringify(failure.mock.calls)).not.toContain(
+      "review-stream-test-secret",
+    );
+    expect(JSON.stringify(failure.mock.calls)).not.toContain("Bearer");
     expect(output.status).toBe(401);
   });
 });

--- a/apps/worker/src/review-stream.ts
+++ b/apps/worker/src/review-stream.ts
@@ -34,14 +34,31 @@ export type ReviewStreamDependencies = {
   privateKeyPath: string;
   capabilitySecret: string;
   now?: () => Date;
+  onEvent?: (event: ReviewStreamEvent) => void;
   onFailure?: (failure: ReviewStreamFailure) => void;
 };
 
-export type ReviewStreamFailure = {
-  stage:
-    "capability" | "authorization" | "binding" | "key" | "storage" | "stream";
-  errorClass: string;
+export type ReviewStreamStage =
+  | "capability"
+  | "authorization"
+  | "binding"
+  | "key"
+  | "storage"
+  | "stream";
+
+export type ReviewStreamEvent = {
+  attemptId: string;
+  stage: ReviewStreamStage;
+  bytesExpected?: number | null;
+  bytesSent?: number;
+  contentTypePresent?: boolean;
+  contentLengthPresent?: boolean;
+  aborted?: boolean;
+  httpStatus?: number;
+  errorClass?: string;
 };
+
+export type ReviewStreamFailure = ReviewStreamEvent;
 
 type EvidenceStreamAuditAction =
   "evidence.stream.started" | "evidence.stream.completed";
@@ -89,14 +106,33 @@ export async function handleReviewEvidenceRequest(
   }
 
   const now = dependencies.now?.() ?? new Date();
-  let stage: ReviewStreamFailure["stage"] = "capability";
+  const attemptId = match[1] ?? "";
+  let stage: ReviewStreamStage = "capability";
+  let bytesExpected: number | null = null;
+  let bytesSent = 0;
+  let contentTypePresent = false;
+  let contentLengthPresent = false;
+  const emit = (event: Partial<ReviewStreamEvent> = {}): void => {
+    const payload: ReviewStreamEvent = {
+      attemptId,
+      stage,
+      bytesExpected,
+      bytesSent,
+      contentTypePresent,
+      contentLengthPresent,
+      ...event,
+    };
+    dependencies.onEvent?.(payload);
+    if (payload.errorClass !== undefined) {
+      dependencies.onFailure?.(payload);
+    }
+  };
   try {
     const capability = verifyWorkerEvidenceCapability(
       bearer,
       dependencies.capabilitySecret,
       now,
     );
-    const attemptId = match[1];
     if (capability.attemptId !== attemptId) {
       throw new WorkerEvidenceCapabilityError(
         "Capability belongs to another attempt",
@@ -134,6 +170,9 @@ export async function handleReviewEvidenceRequest(
       );
     }
 
+    bytesExpected = finalization.manifest.totalPlaintextBytes;
+    contentTypePresent = Boolean(finalization.manifest.codec);
+    contentLengthPresent = true;
     response.writeHead(200, {
       "cache-control": "private, no-store, max-age=0",
       "content-disposition": "inline",
@@ -142,6 +181,7 @@ export async function handleReviewEvidenceRequest(
       "x-content-type-options": "nosniff",
     });
     stage = "stream";
+    emit({ httpStatus: 200 });
     const ciphertext = await dependencies.storage.getObjectStream(
       row.object_key,
     );
@@ -149,9 +189,13 @@ export async function handleReviewEvidenceRequest(
       ciphertext,
       finalization.manifest,
       encryptionKey,
-      async (plaintext) => writeResponse(response, plaintext),
+      async (plaintext) => {
+        await writeResponse(response, plaintext);
+        bytesSent += plaintext.byteLength;
+      },
     );
     response.end();
+    emit({ httpStatus: 200, aborted: false });
     await writeEvidenceStreamAudit(
       (sql, values) => dependencies.database.pool.query(sql, values),
       {
@@ -162,12 +206,15 @@ export async function handleReviewEvidenceRequest(
       },
     );
   } catch (error) {
-    dependencies.onFailure?.({
-      stage,
-      errorClass: error instanceof Error ? error.name : "UnknownError",
+    const errorClass = error instanceof Error ? error.name : "UnknownError";
+    const aborted = response.headersSent && !response.writableEnded;
+    const status = error instanceof WorkerEvidenceCapabilityError ? 401 : 403;
+    emit({
+      errorClass,
+      aborted,
+      httpStatus: response.headersSent ? 200 : status,
     });
     if (!response.headersSent) {
-      const status = error instanceof WorkerEvidenceCapabilityError ? 401 : 403;
       jsonError(
         response,
         status,

--- a/docs/operations/observability.md
+++ b/docs/operations/observability.md
@@ -21,6 +21,8 @@ Forbidden dimensions and values:
 - object keys, presigned URLs, secret/key names or secret-derived hashes;
 - arbitrary provider model output or exception messages.
 
+Structured `evaluation.run` and `evidence.stream` info logs may include attemptId plus content-free enums (stage, hopUsed, httpStatus, byte counts); those fields are diagnostic, not metric dimensions.
+
 The value-free `/api/health/live` answers only process liveness.
 `/api/health/ready` performs bounded DB, pg-boss and S3 `HeadBucket` capability
 checks and returns only `ready` or `unavailable`; it never lists, reads or writes

--- a/packages/observability/src/index.ts
+++ b/packages/observability/src/index.ts
@@ -1,5 +1,7 @@
 import pino, { type Logger, type LoggerOptions } from "pino";
 
+export type { Logger };
+
 const redactionPaths = [
   "req.headers.authorization",
   "req.headers.cookie",

--- a/packages/providers/src/contracts.ts
+++ b/packages/providers/src/contracts.ts
@@ -1,5 +1,6 @@
 import { GitShaSchema, Sha256Schema, UuidSchema } from "@slopproof/domain";
 import { z } from "zod";
+import { JudgeEvaluateFailureDiagnosticsV1Schema } from "./judge-diagnostics";
 
 export const UntrustedDataSchema = z
   .object({
@@ -580,9 +581,11 @@ export const AuthoritativeMultimodalEvaluationV1Schema = z
         outcome: z.enum(["generated", "repaired", "fallback"]),
         degraded: z.boolean(),
         completedAt: ExactReviewDateSchema,
+        failureDiagnostics: JudgeEvaluateFailureDiagnosticsV1Schema.optional(),
       })
       .strict(),
     frameWarnings: z.array(AuthoritativeFrameWarningCodeV1Schema).max(10),
+    frameCount: z.number().int().nonnegative().max(32).optional(),
     workflowOutcome: z.literal("review_required"),
     manualReviewRequired: z.literal(true),
     createdAt: ExactReviewDateSchema,

--- a/packages/providers/src/errors.ts
+++ b/packages/providers/src/errors.ts
@@ -72,12 +72,22 @@ export function isTransientUpstreamHttpStatus(status: number): boolean {
   );
 }
 
+export const JUDGE_HOP_USED = [
+  "primary",
+  "transport_fallback",
+  "none",
+] as const;
+
+export type JudgeHopUsed = (typeof JUDGE_HOP_USED)[number];
+
 type ProviderErrorOptions = ErrorOptions & {
   telemetry?: ProviderFailureTelemetry;
+  hopUsed?: JudgeHopUsed;
 };
 
 export class ProviderError extends Error {
   readonly telemetry: ProviderFailureTelemetry | undefined;
+  readonly hopUsed: JudgeHopUsed | undefined;
 
   constructor(
     readonly code: ProviderErrorCode,
@@ -88,6 +98,7 @@ export class ProviderError extends Error {
     super(message, options);
     this.name = "ProviderError";
     this.telemetry = options?.telemetry;
+    this.hopUsed = options?.hopUsed;
   }
 }
 

--- a/packages/providers/src/hetzner-multimodal.test.ts
+++ b/packages/providers/src/hetzner-multimodal.test.ts
@@ -427,6 +427,12 @@ describe("HetznerMultimodalJudgeProvider", () => {
       expect(failure).toMatchObject({
         code: "PROVIDER_UNAVAILABLE",
         disposition: "retryable",
+        telemetry: {
+          lastFailureKind: "upstream_unavailable",
+          httpStatusClass: "4xx",
+          transportAttemptCount: 3,
+          httpStatus: status,
+        },
       });
       expect(String(failure)).not.toContain(API_KEY);
       expect(String(failure)).not.toContain("private-body");
@@ -434,6 +440,42 @@ describe("HetznerMultimodalJudgeProvider", () => {
       expect(sleep).toHaveBeenCalledTimes(2);
     },
   );
+
+  it("skips a no-op same-model vision hop and fails closed on HTTP 400", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(null, { status: 400 }));
+    let failure: unknown;
+    try {
+      await new HetznerMultimodalJudgeProvider(
+        {
+          provider: "openrouter",
+          baseUrl: "https://openrouter.example.test/api/v1",
+          apiKey: API_KEY,
+          model: "xiaomi/mimo-v2.5",
+          visionModel: "xiaomi/mimo-v2.5",
+        },
+        {
+          fetchImpl,
+          policy: {
+            maxAttempts: 3,
+            attemptTimeoutMs: 100,
+            now: () => NOW.getTime(),
+            random: () => 0,
+            sleep: async () => undefined,
+          },
+        },
+      ).evaluate(inputFixture(), contextFixture());
+    } catch (error) {
+      failure = error;
+    }
+    expect(failure).toMatchObject({
+      code: "PROVIDER_UNAVAILABLE",
+      disposition: "terminal",
+      telemetry: { httpStatus: 400, lastFailureKind: "request_rejected" },
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
 
   it.each([402, 404, 408])(
     "retries HTTP %s then hops to the Hetzner judge fallback",

--- a/packages/providers/src/hetzner-multimodal.ts
+++ b/packages/providers/src/hetzner-multimodal.ts
@@ -1,8 +1,16 @@
 import { createHash } from "node:crypto";
 import { GitShaSchema, Sha256Schema, UuidSchema } from "@slopproof/domain";
 import { z } from "zod";
-import { ProviderError, isTransientUpstreamHttpStatus } from "./errors";
+import {
+  ProviderError,
+  httpStatusClassFor,
+  isTransientUpstreamHttpStatus,
+  safeHttpStatus,
+  type ProviderFailureTelemetry,
+  type ProviderHttpStatusClass,
+} from "./errors";
 import { ProviderContextV1Schema, type ProviderContextV1 } from "./contracts";
+import { JudgeEvaluateFailureDiagnosticsV1Schema } from "./judge-diagnostics";
 
 const MAX_TRANSPORT_ATTEMPTS = 3;
 const DEFAULT_ATTEMPT_TIMEOUT_MS = 20_000;
@@ -332,6 +340,7 @@ export const MultimodalJudgeInvocationMetadataV1Schema = z
     outcome: z.enum(["generated", "repaired", "fallback"]),
     degraded: z.boolean(),
     completedAt: z.date(),
+    failureDiagnostics: JudgeEvaluateFailureDiagnosticsV1Schema.optional(),
   })
   .strict();
 
@@ -417,6 +426,8 @@ type ResolvedRequestPolicy = {
 type RetryableFailure = {
   kind: "network" | "timeout" | "rate_limited" | "unavailable";
   retryAfterMs?: number;
+  httpStatus?: number;
+  httpStatusClass?: ProviderHttpStatusClass;
 };
 
 type CandidateValidationCode =
@@ -757,14 +768,20 @@ export function manualReviewFallbackMultimodalJudgeResultV1(
     "provider_evaluation_unavailable",
   ],
   completedAt: Date = new Date(),
+  diagnostics?: z.input<typeof JudgeEvaluateFailureDiagnosticsV1Schema>,
 ): MultimodalJudgeProviderResultV1 {
   const input = MultimodalJudgeProviderInputV1Schema.safeParse(rawInput);
   const descriptor =
     InlineMultimodalJudgeDescriptorV1Schema.safeParse(rawDescriptor);
+  const parsedDiagnostics =
+    diagnostics === undefined
+      ? undefined
+      : JudgeEvaluateFailureDiagnosticsV1Schema.safeParse(diagnostics);
   if (
     !input.success ||
     !descriptor.success ||
-    !Number.isFinite(completedAt.getTime())
+    !Number.isFinite(completedAt.getTime()) ||
+    (parsedDiagnostics !== undefined && !parsedDiagnostics.success)
   ) {
     throw invalidInputError();
   }
@@ -781,11 +798,14 @@ export function manualReviewFallbackMultimodalJudgeResultV1(
       inputHash: hashProviderInput(input.data),
       outputHash: hashUnknown(candidate),
       tokenUsage: null,
-      latencyMs: 0,
-      invocationCount: 0,
+      latencyMs: parsedDiagnostics?.data.latencyMs ?? 0,
+      invocationCount: parsedDiagnostics?.data.invocationCount ?? 0,
       outcome: "fallback",
       degraded: true,
       completedAt,
+      ...(parsedDiagnostics === undefined
+        ? {}
+        : { failureDiagnostics: parsedDiagnostics.data }),
     },
   });
 }
@@ -999,6 +1019,8 @@ async function requestJsonWithRetry(input: {
         } else if (error.status === 429) {
           lastFailure = {
             kind: "rate_limited",
+            httpStatusClass: "4xx",
+            httpStatus: error.status,
             ...(response === undefined
               ? {}
               : {
@@ -1009,12 +1031,25 @@ async function requestJsonWithRetry(input: {
                 }),
           };
         } else if (isTransientUpstreamHttpStatus(error.status)) {
-          lastFailure = { kind: "unavailable" };
+          lastFailure = {
+            kind: "unavailable",
+            httpStatusClass: httpStatusClassFor(error.status) ?? "5xx",
+            httpStatus: error.status,
+          };
         } else {
+          const httpStatus = safeHttpStatus(error.status);
           throw new ProviderError(
             "PROVIDER_UNAVAILABLE",
             "terminal",
             "Multimodal provider rejected the bounded request",
+            {
+              telemetry: {
+                lastFailureKind: "request_rejected",
+                httpStatusClass: httpStatusClassFor(error.status) ?? "4xx",
+                transportAttemptCount: attempt,
+                ...(httpStatus === undefined ? {} : { httpStatus }),
+              },
+            },
           );
         }
       } else {
@@ -1027,7 +1062,7 @@ async function requestJsonWithRetry(input: {
       if (timeout !== undefined) clearTimeout(timeout);
     }
     if (attempt === input.policy.maxAttempts) {
-      throw retryableProviderError(lastFailure);
+      throw retryableProviderError(lastFailure, attempt);
     }
     const delay = Math.max(
       jitteredBackoffMilliseconds(attempt, input.policy.random),
@@ -1038,7 +1073,7 @@ async function requestJsonWithRetry(input: {
     }
     await input.policy.sleep(delay);
   }
-  throw retryableProviderError(lastFailure);
+  throw retryableProviderError(lastFailure, input.policy.maxAttempts);
 }
 
 async function readBoundedResponseText(
@@ -1351,22 +1386,49 @@ function invalidOutputError(): ProviderError {
   );
 }
 
-function deadlineError(): ProviderError {
+function deadlineError(telemetry?: ProviderFailureTelemetry): ProviderError {
   return new ProviderError(
     "DEADLINE_EXCEEDED",
     "retryable",
     "Multimodal provider deadline elapsed",
+    {
+      telemetry: telemetry ?? {
+        lastFailureKind: "deadline_exceeded",
+        httpStatusClass: null,
+        transportAttemptCount: 0,
+      },
+    },
   );
 }
 
 function retryableProviderError(
   failure: RetryableFailure | undefined,
+  transportAttemptCount: number,
 ): ProviderError {
   return failure?.kind === "timeout"
-    ? deadlineError()
+    ? deadlineError(retryableFailureTelemetry(failure, transportAttemptCount))
     : new ProviderError(
         "PROVIDER_UNAVAILABLE",
         "retryable",
         "Multimodal provider is temporarily unavailable",
+        {
+          telemetry: retryableFailureTelemetry(failure, transportAttemptCount),
+        },
       );
+}
+
+function retryableFailureTelemetry(
+  failure: RetryableFailure | undefined,
+  transportAttemptCount: number,
+): ProviderFailureTelemetry {
+  const httpStatus = safeHttpStatus(failure?.httpStatus);
+  return {
+    lastFailureKind:
+      failure?.kind === "unavailable"
+        ? "upstream_unavailable"
+        : (failure?.kind ?? "deadline_exceeded"),
+    httpStatusClass: failure?.httpStatusClass ?? null,
+    transportAttemptCount,
+    ...(httpStatus === undefined ? {} : { httpStatus }),
+  };
 }

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -3,6 +3,7 @@ export * from "./errors";
 export * from "./fakes";
 export * from "./hetzner-multimodal";
 export * from "./hetzner-semantic";
+export * from "./judge-diagnostics";
 export * from "./learning-proof";
 export * from "./openrouter-transcription";
 export * from "./payload-cipher";

--- a/packages/providers/src/judge-diagnostics.test.ts
+++ b/packages/providers/src/judge-diagnostics.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { ProviderError } from "./errors";
+import { describeJudgeEvaluateFailure } from "./judge-diagnostics";
+
+describe("judge evaluate failure diagnostics", () => {
+  it("keeps 404/402 enums and hopUsed without the provider message", () => {
+    const diagnostics = describeJudgeEvaluateFailure(
+      new ProviderError(
+        "PROVIDER_UNAVAILABLE",
+        "retryable",
+        "private raw provider payload and API key",
+        {
+          hopUsed: "primary",
+          telemetry: {
+            lastFailureKind: "upstream_unavailable",
+            httpStatusClass: "4xx",
+            transportAttemptCount: 3,
+            httpStatus: 404,
+          },
+        },
+      ),
+      { hopUsed: "none", latencyMs: 3400, frameCount: 1 },
+    );
+    expect(diagnostics).toMatchObject({
+      httpStatus: 404,
+      errorClass: "ProviderError",
+      errorCode: "PROVIDER_UNAVAILABLE",
+      disposition: "retryable",
+      lastFailureKind: "upstream_unavailable",
+      hopUsed: "primary",
+      invocationCount: 1,
+      latencyMs: 3400,
+      frameCount: 1,
+    });
+    expect(JSON.stringify(diagnostics)).not.toContain("private raw provider");
+  });
+
+  it("records a network failure as transport without an HTTP status", () => {
+    expect(
+      describeJudgeEvaluateFailure(
+        new ProviderError(
+          "PROVIDER_UNAVAILABLE",
+          "retryable",
+          "Multimodal provider is temporarily unavailable",
+          {
+            telemetry: {
+              lastFailureKind: "network",
+              httpStatusClass: null,
+              transportAttemptCount: 1,
+            },
+          },
+        ),
+        { hopUsed: "none", latencyMs: 12, frameCount: 0 },
+      ),
+    ).toMatchObject({
+      lastFailureKind: "network",
+      hopUsed: "none",
+      invocationCount: 1,
+    });
+  });
+});

--- a/packages/providers/src/judge-diagnostics.ts
+++ b/packages/providers/src/judge-diagnostics.ts
@@ -1,0 +1,128 @@
+import { z } from "zod";
+import {
+  JUDGE_HOP_USED,
+  PROVIDER_ERROR_CODES,
+  PROVIDER_FAILURE_KINDS,
+  ProviderError,
+  safeHttpStatus,
+  type JudgeHopUsed,
+  type ProviderErrorCode,
+  type ProviderErrorDisposition,
+  type ProviderFailureKind,
+} from "./errors";
+
+export const JudgeHopUsedSchema = z.enum(JUDGE_HOP_USED);
+
+export const JudgeEvaluateFailureDiagnosticsV1Schema = z
+  .object({
+    httpStatus: z.number().int().min(100).max(599).optional(),
+    errorClass: z.enum(["ProviderError", "Error", "UnknownError"]),
+    errorCode: z.enum(PROVIDER_ERROR_CODES).optional(),
+    disposition: z.enum(["retryable", "terminal", "review"]).optional(),
+    lastFailureKind: z.enum(PROVIDER_FAILURE_KINDS).optional(),
+    hopUsed: JudgeHopUsedSchema,
+    invocationCount: z.union([z.literal(0), z.literal(1), z.literal(2)]),
+    latencyMs: z
+      .number()
+      .int()
+      .nonnegative()
+      .max(15 * 60_000),
+    frameCount: z.number().int().nonnegative().max(32),
+  })
+  .strict();
+
+export type JudgeEvaluateFailureDiagnosticsV1 = z.infer<
+  typeof JudgeEvaluateFailureDiagnosticsV1Schema
+>;
+
+export function annotateProviderErrorHopUsed(
+  error: unknown,
+  hopUsed: JudgeHopUsed,
+): unknown {
+  if (!(error instanceof ProviderError)) return error;
+  if (error.hopUsed === hopUsed) return error;
+  return new ProviderError(error.code, error.disposition, error.message, {
+    cause: error,
+    hopUsed,
+    ...(error.telemetry === undefined ? {} : { telemetry: error.telemetry }),
+  });
+}
+
+export function describeJudgeEvaluateFailure(
+  error: unknown,
+  input: {
+    hopUsed: JudgeHopUsed;
+    latencyMs: number;
+    frameCount: number;
+  },
+): JudgeEvaluateFailureDiagnosticsV1 {
+  const latencyMs = Math.min(
+    15 * 60_000,
+    Math.max(0, Math.floor(input.latencyMs)),
+  );
+  const frameCount = Math.min(32, Math.max(0, Math.floor(input.frameCount)));
+  if (error instanceof ProviderError) {
+    const httpStatus = safeHttpStatus(error.telemetry?.httpStatus);
+    const hopUsed = error.hopUsed ?? input.hopUsed;
+    return JudgeEvaluateFailureDiagnosticsV1Schema.parse({
+      ...(httpStatus === undefined ? {} : { httpStatus }),
+      errorClass: "ProviderError",
+      errorCode: error.code,
+      disposition: error.disposition,
+      ...(error.telemetry === undefined
+        ? {}
+        : { lastFailureKind: error.telemetry.lastFailureKind }),
+      hopUsed,
+      invocationCount: invocationCountForFailure(hopUsed),
+      latencyMs,
+      frameCount,
+    });
+  }
+  return JudgeEvaluateFailureDiagnosticsV1Schema.parse({
+    errorClass: error instanceof Error ? "Error" : "UnknownError",
+    hopUsed: input.hopUsed,
+    invocationCount: input.hopUsed === "transport_fallback" ? 2 : 1,
+    latencyMs,
+    frameCount,
+  });
+}
+
+function invocationCountForFailure(hopUsed: JudgeHopUsed): 0 | 1 | 2 {
+  return hopUsed === "transport_fallback" ? 2 : 1;
+}
+
+export type JudgeEvaluateFailureSummary = {
+  httpStatus?: number;
+  errorClass?: JudgeEvaluateFailureDiagnosticsV1["errorClass"];
+  errorCode?: ProviderErrorCode;
+  disposition?: ProviderErrorDisposition;
+  lastFailureKind?: ProviderFailureKind;
+  hopUsed: JudgeHopUsed;
+  invocationCount: 0 | 1 | 2;
+  latencyMs: number;
+  frameCount: number;
+};
+
+export function judgeFailureLogFields(
+  diagnostics: JudgeEvaluateFailureDiagnosticsV1,
+): JudgeEvaluateFailureSummary {
+  return {
+    ...(diagnostics.httpStatus === undefined
+      ? {}
+      : { httpStatus: diagnostics.httpStatus }),
+    errorClass: diagnostics.errorClass,
+    ...(diagnostics.errorCode === undefined
+      ? {}
+      : { errorCode: diagnostics.errorCode }),
+    ...(diagnostics.disposition === undefined
+      ? {}
+      : { disposition: diagnostics.disposition }),
+    ...(diagnostics.lastFailureKind === undefined
+      ? {}
+      : { lastFailureKind: diagnostics.lastFailureKind }),
+    hopUsed: diagnostics.hopUsed,
+    invocationCount: diagnostics.invocationCount,
+    latencyMs: diagnostics.latencyMs,
+    frameCount: diagnostics.frameCount,
+  };
+}

--- a/packages/providers/src/transport-fallback.test.ts
+++ b/packages/providers/src/transport-fallback.test.ts
@@ -428,6 +428,96 @@ describe("TransportFallbackMultimodalJudgeProvider", () => {
     ).rejects.toMatchObject({ code: "INVALID_OUTPUT" });
     expect(fallback.evaluate).not.toHaveBeenCalled();
   });
+
+  it("annotates hopUsed=primary when the judge does not hop", async () => {
+    const fallback = stubJudgeProvider(
+      {
+        provider: "hetzner-inference",
+        model: "hetzner-judge",
+        visionModel: "hetzner-vision",
+      },
+      () => {
+        throw new Error("fallback must not run");
+      },
+    );
+
+    await expect(
+      new TransportFallbackMultimodalJudgeProvider(
+        stubJudgeProvider(
+          {
+            provider: "openrouter",
+            model: "xiaomi/mimo-v2.5",
+            visionModel: "xiaomi/mimo-v2.5",
+          },
+          () => {
+            throw new ProviderError(
+              "INVALID_OUTPUT",
+              "review",
+              "Multimodal provider output is invalid",
+            );
+          },
+        ),
+        fallback,
+      ).evaluate({} as MultimodalJudgeProviderInputV1, judgeContext()),
+    ).rejects.toMatchObject({
+      code: "INVALID_OUTPUT",
+      hopUsed: "primary",
+    });
+    expect(fallback.evaluate).not.toHaveBeenCalled();
+  });
+
+  it("annotates hopUsed=transport_fallback after a hopped 404 then fallback failure", async () => {
+    await expect(
+      new TransportFallbackMultimodalJudgeProvider(
+        stubJudgeProvider(
+          {
+            provider: "openrouter",
+            model: "xiaomi/mimo-v2.5",
+            visionModel: "xiaomi/mimo-v2.5",
+          },
+          () => {
+            throw new ProviderError(
+              "PROVIDER_UNAVAILABLE",
+              "retryable",
+              "Multimodal provider is temporarily unavailable",
+              {
+                telemetry: {
+                  lastFailureKind: "upstream_unavailable",
+                  httpStatusClass: "4xx",
+                  transportAttemptCount: 3,
+                  httpStatus: 404,
+                },
+              },
+            );
+          },
+        ),
+        stubJudgeProvider(
+          {
+            provider: "hetzner-inference",
+            model: "hetzner-judge",
+            visionModel: "hetzner-vision",
+          },
+          () => {
+            throw new ProviderError(
+              "PROVIDER_UNAVAILABLE",
+              "retryable",
+              "Multimodal provider is temporarily unavailable",
+              {
+                telemetry: {
+                  lastFailureKind: "network",
+                  httpStatusClass: null,
+                  transportAttemptCount: 1,
+                },
+              },
+            );
+          },
+        ),
+      ).evaluate({} as MultimodalJudgeProviderInputV1, judgeContext()),
+    ).rejects.toMatchObject({
+      hopUsed: "transport_fallback",
+      telemetry: { lastFailureKind: "network" },
+    });
+  });
 });
 
 function transportUnavailable(): ProviderError {

--- a/packages/providers/src/transport-fallback.ts
+++ b/packages/providers/src/transport-fallback.ts
@@ -1,4 +1,5 @@
 import { isTransportFailure } from "./errors";
+import { annotateProviderErrorHopUsed } from "./judge-diagnostics";
 import {
   SemanticProviderDescriptorV1Schema,
   SemanticProviderRawResponseV1Schema,
@@ -99,8 +100,17 @@ export class TransportFallbackMultimodalJudgeProvider implements InlineMultimoda
     try {
       return await this.primary.evaluate(input, context);
     } catch (error) {
-      if (!isTransportFailure(error)) throw error;
-      return await this.fallback.evaluate(input, context);
+      if (!isTransportFailure(error)) {
+        throw annotateProviderErrorHopUsed(error, "primary");
+      }
+      try {
+        return await this.fallback.evaluate(input, context);
+      } catch (fallbackError) {
+        throw annotateProviderErrorHopUsed(
+          fallbackError,
+          "transport_fallback",
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Change

Fixes live review playback and persists enough judge/video telemetry that the next production fallback can be diagnosed. Does not rewrite attempt `1f0a6d03-6f75-5c6b-afd4-8cc65338dada` (sidecars are immutable).

### Live incident (2026-08-21)

Attempt `1f0a6d03-6f75-5c6b-afd4-8cc65338dada` (PR 20 head `e57ab38`) on https://slopproof.paskie.me/review/1f0a6d03-6f75-5c6b-afd4-8cc65338dada had two independent breaks. Live is `1e845c9` / release `20260821T124023Z`.

**Video.** The recording existed and was playable in storage (R2 HEAD 200, 11_301_489 bytes). The worker decrypted and streamed twice (`evidence.stream.started/completed` at 14:26:15Z and 14:26:21Z). Caddy logged `aborting with incomplete response` / `context canceled` on `GET /api/review/…/evidence` at 14:26:17Z after 0.83s. The UI showed the generic catch: "The video is not available. Request fresh access and try again."

The player required `Content-Length` to be a positive safe integer and `blob.size === contentLength`. Next can strip `Content-Length` on the proxied stream. `Number(null)` is `0`, so the player threw **before reading the body**, the browser aborted the fetch, and Caddy saw a canceled incomplete response. The worker still finished writing (audit completed).

This PR keeps the one-use capability / no object-store URL / no key-in-browser contract and still buffers to a blob (a `<video>` range request would consume the JTI). It no longer requires `Content-Length` to play a valid WebM body. Missing or mismatched length, abort, and incomplete transfer are retryable: the player requests a fresh capability automatically (up to two retries) and says the transfer was interrupted instead of "the video is not available."

**Judge.** PR 23 is live (`evaluate` always called; 402/404/408 treated as transport). `evaluation.run` finished in ~3.4s with outcome `completed`. One frame loaded (`frameWarnings=[]`). The sidecar decrypted to `outcome=fallback`, `invocationCount=0`, `degraded=true`, `latencyMs=0`, `provider=openrouter`, `model=xiaomi/mimo-v2.5`. The UI string "Judge did not finish." is the fallback sidecar, not "still running." Worker stdout was only `worker.ready` / `SIGTERM`. `manualReviewFallbackMultimodalJudgeResultV1` always stamped `invocationCount 0` / `latencyMs 0`, so a failed HTTP attempt was indistinguishable from "never called." Same-model vision fallback (`xiaomi/mimo-v2.5` === text model) is a no-op and is now skipped / fail-closed rather than pretended as a second hop. Hop status mapping is unchanged.

### What changed

1. **Player / evidence stream**
   - Valid WebM plays when `Content-Length` is missing.
   - Abort / incomplete transfer shows a retryable message and automatically requests a fresh capability once or twice.
   - Worker + web info logs for evidence streams: `attemptId`, `stage` (`capability|authorization|binding|key|storage|stream|proxy|client`), `bytesExpected`, `bytesSent`/`bytesReceived`, content-type/length present, abort/cancel, HTTP status. No object keys, wrapped keys, cookies, or JWTs.

2. **Judge fallback telemetry (new proofs only)**
   - When `evaluate()` throws and we write `manualReviewFallback`, persist `httpStatus`, error class/code, disposition, `lastFailureKind`, `hopUsed` (`primary` | `transport_fallback` | `none`), actual `invocationCount`, `latencyMs`, `frameCount`, and `frameWarnings`.
   - Those enums are on the sidecar (`invocationMetadata.failureDiagnostics`), on `evaluation.run` job output (`judge`), and on worker info logs (`worker.evaluation.run`).
   - Multimodal provider errors now carry the same content-free HTTP telemetry the semantic path already had (needed to persist `httpStatus`). Hop mapping is not changed.
   - Same-model vision hop is skipped and fails closed on HTTP 400 instead of retrying the identical model.

3. **Logging hygiene**
   - `evaluation.run` and `evidence.stream` are visible at `LOG_LEVEL=info`.
   - PII/secret redaction tests remain. One line added to `docs/operations/observability.md`: those info logs may include `attemptId` plus content-free enums as diagnostics, not metric dimensions.

### What a future on-call will see

- **Video abort:** `web.evidence.stream` / `worker.evidence.stream` with `attemptId`, `stage`, `httpStatus`, `contentLengthPresent`, `bytesExpected`, `bytesSent`, `aborted`. If Next strips `Content-Length`, the player still consumes the body and plays when the WebM is complete.
- **Judge fallback:** decrypt the new sidecar or read pg-boss `evaluation.run` output / worker info logs for `hopUsed`, `httpStatus`, `errorCode`, `disposition`, `lastFailureKind`, `invocationCount`, `latencyMs`, `frameCount`, `frameWarnings`. A failed HTTP attempt will no longer look like `invocationCount=0` / `latencyMs=0` with no error class.
- Attempt `1f0a6d03-…` cannot be rewritten. This only helps the next proof.

## Failure mode

- Playback still fails closed on CSRF missing, capability rejection, non-WebM content type, or a body larger than `MAX_RECORDING_OBJECT_BYTES`. Interrupted transfers retry with a new one-use capability; they do not reuse a consumed JTI or expose an object-store URL.
- Judge evaluate failures still persist a manual-review fallback sidecar. Diagnostics are enums only (no transcript, judge opinion, prompts, image bytes, API keys, or raw provider bodies). Old sidecars without the new optional fields still parse.
- Same-model vision hop fails closed on terminal 400 instead of pretending a second model ran. 402/404/408 hop mapping is unchanged.

## Verification

- [x] Unit or contract tests
- [ ] PostgreSQL integration tests when state or concurrency changed
- [ ] Playwright coverage when a user flow changed
- [ ] Threat model or provider data-flow update when a boundary changed
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` (843 passed)
- [ ] `pnpm audit:secrets`
- [x] No credentials, private repository data or evidence artifacts included

Player: missing `Content-Length` + valid WebM plays; abort/incomplete is retryable; matching `Content-Length` success path unchanged.

Judge: thrown `evaluate` with mocked 404/402/network records `httpStatus` / error class / `hopUsed`; success path does not log payloads. Existing hop tests (PR 23) stay green. Auth, capability one-use, and encryption tests were not weakened.

## Privacy and public output

- Sidecar / job output / logs: optional `failureDiagnostics` and `evaluation.run` `judge` enums (`httpStatus`, `errorClass`, `errorCode`, `disposition`, `lastFailureKind`, `hopUsed`, `invocationCount`, `latencyMs`, `frameCount`, `frameWarnings`).
- Info logs: `worker.evaluation.run`, `worker.evidence.stream`, `web.evidence.stream` (and browser `console.info` `slopproof.evidence.stream` for the client stage).
- Optional `frameCount` on new authoritative evaluations.
- No new HTTP routes, GitHub permissions, Check output, or metric labels.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ffde382d-c64a-4e68-9d1e-3eb58b97dc84?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ffde382d-c64a-4e68-9d1e-3eb58b97dc84&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

