### PR TITLE
fix: repair judge output and review playback auth

### DIFF
--- a/apps/web/app/api/review/[attemptId]/evidence-capability/route.ts
+++ b/apps/web/app/api/review/[attemptId]/evidence-capability/route.ts
@@ -8,7 +8,10 @@ import {
   EVIDENCE_CAPABILITY_MAX_TTL_MS,
   issueEvidenceCapability,
 } from "../../../../../lib/evidence-capability";
-import { requireMutationSession } from "../../../../../lib/http-auth";
+import {
+  HttpAuthError,
+  requireMutationSession,
+} from "../../../../../lib/http-auth";
 import {
   requireEvidenceAccess,
   writeReviewAudit,
@@ -106,6 +109,7 @@ export async function POST(
     });
     return response;
   } catch (error) {
+    const mappedResponse = reviewRouteErrorResponse(error);
     const attemptId = await context.params
       .then((params) => ReviewAttemptIdSchema.safeParse(params.attemptId).data)
       .catch(() => undefined);
@@ -114,17 +118,15 @@ export async function POST(
         attemptId,
         stage: "capability",
         errorClass: error instanceof Error ? error.name : "UnknownError",
+        ...(error instanceof HttpAuthError ? { errorCode: error.code } : {}),
         ...(error instanceof InvalidRequestBodyError
           ? { httpStatus: 400 }
-          : {}),
+          : { httpStatus: mappedResponse?.status ?? 503 }),
       });
     }
     if (error instanceof InvalidRequestBodyError) {
       return jsonError("invalid_request", 400);
     }
-    return (
-      reviewRouteErrorResponse(error) ??
-      jsonError("temporarily_unavailable", 503)
-    );
+    return mappedResponse ?? jsonError("temporarily_unavailable", 503);
   }
 }

--- a/apps/web/lib/evidence-playback.test.ts
+++ b/apps/web/lib/evidence-playback.test.ts
@@ -46,6 +46,10 @@ describe("review evidence playback", () => {
       expiresAt: "2026-08-21T14:30:00.000Z",
     });
     expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl.mock.calls[0]?.[1]).toMatchObject({
+      method: "POST",
+      credentials: "same-origin",
+    });
   });
 
   it("retries an aborted transfer with a fresh capability and then plays", async () => {
@@ -238,6 +242,47 @@ describe("review evidence playback", () => {
       }),
     ).rejects.toBeInstanceOf(EvidencePlaybackError);
     expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("explains a rotated OAuth/CSRF pair instead of calling it a video transfer", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ error: "csrf_rejected" }), {
+        status: 403,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    await expect(
+      loadReviewEvidencePlayback({
+        attemptId: ATTEMPT_ID,
+        csrf: "stale-csrf-token",
+        fetchImpl,
+      }),
+    ).rejects.toMatchObject({
+      code: "capability_rejected",
+      retryable: false,
+      message:
+        "Your review session changed. Authorize with GitHub again, then retry.",
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("distinguishes an interrupted capability request from a video transfer", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockRejectedValue(new TypeError("private network detail"));
+
+    await expect(
+      loadReviewEvidencePlayback({
+        attemptId: ATTEMPT_ID,
+        csrf: "csrf-token",
+        fetchImpl,
+        maxAutomaticRetries: 0,
+      }),
+    ).rejects.toMatchObject({
+      code: "capability_rejected",
+      message: "The evidence access request was interrupted. Try again.",
+    });
   });
 });
 

--- a/apps/web/lib/evidence-playback.ts
+++ b/apps/web/lib/evidence-playback.ts
@@ -113,7 +113,11 @@ async function attemptEvidencePlayback(input: {
   try {
     const response = await input.fetchImpl(
       `/api/review/${input.attemptId}/evidence-capability`,
-      { method: "POST", headers: { "x-slopproof-csrf": input.csrf } },
+      {
+        method: "POST",
+        credentials: "same-origin",
+        headers: { "x-slopproof-csrf": input.csrf },
+      },
     );
     capabilityStatus = response.status;
     const result = (await response.json().catch(() => null)) as {
@@ -128,7 +132,7 @@ async function attemptEvidencePlayback(input: {
     if (!response.ok || !result?.streamUrl || !result.expiresAt) {
       throw new EvidencePlaybackError(
         "capability_rejected",
-        result?.error ?? "Evidence access was rejected.",
+        capabilityErrorMessage(result?.error),
         response.status >= 500,
       );
     }
@@ -214,12 +218,28 @@ async function attemptEvidencePlayback(input: {
       httpStatus: capabilityStatus,
       aborted: isAbortLike(error),
     });
-    throw new EvidencePlaybackError(
-      "transfer_incomplete",
-      "The recording transfer was interrupted. Request fresh access and try again.",
-      true,
-    );
+    throw capabilityStatus === null
+      ? new EvidencePlaybackError(
+          "capability_rejected",
+          "The evidence access request was interrupted. Try again.",
+          true,
+        )
+      : new EvidencePlaybackError(
+          "transfer_incomplete",
+          "The recording transfer was interrupted. Request fresh access and try again.",
+          true,
+        );
   }
+}
+
+function capabilityErrorMessage(code: string | undefined): string {
+  if (code === "csrf_rejected" || code === "authentication_required") {
+    return "Your review session changed. Authorize with GitHub again, then retry.";
+  }
+  if (code === "forbidden") {
+    return "This GitHub session cannot access the recording.";
+  }
+  return code ?? "Evidence access was rejected.";
 }
 
 function parseDeclaredLength(raw: string | null): number | undefined {

--- a/apps/web/lib/evidence-stream-log.test.ts
+++ b/apps/web/lib/evidence-stream-log.test.ts
@@ -18,6 +18,7 @@ describe("web evidence stream logs", () => {
       contentLengthPresent: false,
       bytesExpected: null,
       aborted: false,
+      errorCode: "csrf_rejected",
     });
     expect(info).toHaveBeenCalledWith(
       {
@@ -28,6 +29,7 @@ describe("web evidence stream logs", () => {
         contentLengthPresent: false,
         aborted: false,
         httpStatus: 200,
+        errorCode: "csrf_rejected",
       },
       "web.evidence.stream",
     );

--- a/apps/web/lib/evidence-stream-log.ts
+++ b/apps/web/lib/evidence-stream-log.ts
@@ -12,6 +12,7 @@ export function logWebEvidenceStream(fields: {
   aborted?: boolean;
   httpStatus?: number;
   errorClass?: string;
+  errorCode?: string;
 }): void {
   const payload = {
     attemptId: fields.attemptId,
@@ -35,6 +36,7 @@ export function logWebEvidenceStream(fields: {
     ...(fields.errorClass === undefined
       ? {}
       : { errorClass: fields.errorClass }),
+    ...(fields.errorCode === undefined ? {} : { errorCode: fields.errorCode }),
   };
   getWebLogger().info(payload, "web.evidence.stream");
   console.info("web.evidence.stream", payload);

--- a/apps/web/lib/github-oauth-routes.test.ts
+++ b/apps/web/lib/github-oauth-routes.test.ts
@@ -269,6 +269,11 @@ describe("GitHub OAuth route handlers", () => {
     const cookies = setCookies(response).join("\n");
     expect(cookies).toContain("slopproof_session=new-session-token");
     expect(cookies).toContain("slopproof_csrf=new-csrf-token");
+    expect(
+      setCookies(response).find((cookie) =>
+        cookie.startsWith("slopproof_csrf="),
+      ),
+    ).toContain("SameSite=lax");
     expect(cookies).toContain(
       `${GITHUB_USER_TOKEN_COOKIE}=v1.sealed-user-token`,
     );

--- a/apps/web/lib/github-oauth-routes.ts
+++ b/apps/web/lib/github-oauth-routes.ts
@@ -328,7 +328,7 @@ function setNoStoreHeaders(response: NextResponse): void {
 
 function clearAllAuthCookies(response: NextResponse): void {
   response.cookies.set(SESSION_COOKIE, "", expiredCookie("/", true, "lax"));
-  response.cookies.set(CSRF_COOKIE, "", expiredCookie("/", false, "strict"));
+  response.cookies.set(CSRF_COOKIE, "", expiredCookie("/", false, "lax"));
   clearFlowCookie(response);
   clearUserTokenCookie(response);
   clearDirectoryCookie(response);

--- a/apps/web/lib/http-auth.test.ts
+++ b/apps/web/lib/http-auth.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { NextResponse } from "next/server";
+import { attachSessionCookies, HttpAuthError } from "./http-auth";
+
+describe("review HTTP auth", () => {
+  it("keeps rotated OAuth session and CSRF cookies on the same Lax policy", () => {
+    const response = new NextResponse(null, { status: 204 });
+    attachSessionCookies(
+      response,
+      {
+        session: {
+          id: "10000000-0000-4000-8000-000000000001",
+          actorId: "42",
+          actorRole: "maintainer",
+          repositoryId: "10000000-0000-4000-8000-000000000002",
+          csrfHash: "a".repeat(64),
+          expiresAt: new Date(Date.now() + 60_000),
+        },
+        sessionToken: "session-token",
+        csrfToken: "csrf-token",
+      },
+      "https://slopproof.example",
+    );
+
+    const cookies = response.headers.getSetCookie();
+    expect(
+      cookies.find((cookie) => cookie.startsWith("slopproof_session=")),
+    ).toContain("SameSite=lax");
+    expect(
+      cookies.find((cookie) => cookie.startsWith("slopproof_csrf=")),
+    ).toContain("SameSite=lax");
+  });
+
+  it("gives authentication failures an observable but content-free class", () => {
+    const error = new HttpAuthError(403, "csrf_rejected");
+    expect(error.name).toBe("HttpAuthError");
+    expect(error).toMatchObject({ status: 403, code: "csrf_rejected" });
+  });
+});

--- a/apps/web/lib/http-auth.ts
+++ b/apps/web/lib/http-auth.ts
@@ -17,6 +17,7 @@ export class HttpAuthError extends Error {
     readonly code: "authentication_required" | "csrf_rejected" | "forbidden",
   ) {
     super(code);
+    this.name = "HttpAuthError";
   }
 }
 
@@ -174,7 +175,10 @@ export function attachSessionCookies(
   response.cookies.set(CSRF_COOKIE, issued.csrfToken, {
     httpOnly: false,
     secure,
-    sameSite: "strict",
+    // The token still has to be echoed in a non-simple same-origin header.
+    // Lax keeps the OAuth callback's rotated session and CSRF pair coherent
+    // across Safari/WebKit's cross-site redirect chain.
+    sameSite: "lax",
     path: "/",
     maxAge,
   });

--- a/apps/web/lib/request-protected-routes.test.ts
+++ b/apps/web/lib/request-protected-routes.test.ts
@@ -22,6 +22,7 @@ import { POST as decideReview } from "../app/api/review/[attemptId]/decision/rou
 import { POST as finalizeUpload } from "../app/api/uploads/finalize/route";
 import { POST as acknowledgePart } from "../app/api/uploads/part-complete/route";
 import { POST as presignPart } from "../app/api/uploads/part-url/route";
+import { HttpAuthError } from "./http-auth";
 
 const ATTEMPT_ID = "10000000-0000-4000-8000-000000000001";
 
@@ -123,6 +124,24 @@ describe("production mutation request-body boundaries", () => {
       expect(forbiddenQuery()).not.toHaveBeenCalled();
     },
   );
+
+  it("returns the exact safe CSRF failure before issuing evidence access", async () => {
+    mocks.requireMutationSession.mockRejectedValueOnce(
+      new HttpAuthError(403, "csrf_rejected"),
+    );
+
+    const response = await call(
+      issueEvidenceCapability,
+      new Request(
+        `https://slopproof.example/api/review/${ATTEMPT_ID}/evidence-capability`,
+        { method: "POST", headers: { "x-slopproof-csrf": "stale-token" } },
+      ),
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "csrf_rejected" });
+    expect(forbiddenQuery()).not.toHaveBeenCalled();
+  });
 });
 
 type RouteHandler = (

--- a/packages/providers/src/errors.ts
+++ b/packages/providers/src/errors.ts
@@ -28,6 +28,33 @@ export const PROVIDER_FAILURE_KINDS = [
 export type ProviderFailureKind = (typeof PROVIDER_FAILURE_KINDS)[number];
 export type ProviderHttpStatusClass = "4xx" | "5xx";
 
+export const PROVIDER_VALIDATION_CODES = [
+  "schema_invalid",
+  "binding_invalid",
+  "content_policy_invalid",
+] as const;
+
+export type ProviderValidationCode = (typeof PROVIDER_VALIDATION_CODES)[number];
+
+export const PROVIDER_VALIDATION_ISSUE_CODES = [
+  "schema_invalid",
+  "unknown_question",
+  "duplicate_question",
+  "unknown_criterion",
+  "duplicate_criterion",
+  "foreign_anchor",
+  "evaluable_without_anchor",
+  "not_evaluable_with_anchor",
+  "result_reason_mismatch",
+  "not_evaluable_reason_mismatch",
+  "missing_criterion",
+  "missing_question",
+  "pass_with_unresolved_or_nonpassing",
+] as const;
+
+export type ProviderValidationIssueCode =
+  (typeof PROVIDER_VALIDATION_ISSUE_CODES)[number];
+
 /**
  * Content-free diagnostics that may cross the provider boundary safely.
  * Never add messages, URLs, request/response bodies, headers, or identifiers.
@@ -83,11 +110,16 @@ export type JudgeHopUsed = (typeof JUDGE_HOP_USED)[number];
 type ProviderErrorOptions = ErrorOptions & {
   telemetry?: ProviderFailureTelemetry;
   hopUsed?: JudgeHopUsed;
+  validationCode?: ProviderValidationCode;
+  validationIssueCodes?: readonly ProviderValidationIssueCode[];
 };
 
 export class ProviderError extends Error {
   readonly telemetry: ProviderFailureTelemetry | undefined;
   readonly hopUsed: JudgeHopUsed | undefined;
+  readonly validationCode: ProviderValidationCode | undefined;
+  readonly validationIssueCodes:
+    readonly ProviderValidationIssueCode[] | undefined;
 
   constructor(
     readonly code: ProviderErrorCode,
@@ -99,6 +131,13 @@ export class ProviderError extends Error {
     this.name = "ProviderError";
     this.telemetry = options?.telemetry;
     this.hopUsed = options?.hopUsed;
+    this.validationCode = options?.validationCode;
+    this.validationIssueCodes =
+      options?.validationIssueCodes === undefined
+        ? undefined
+        : Object.freeze(
+            [...new Set(options.validationIssueCodes)].slice(0, 16),
+          );
   }
 }
 

--- a/packages/providers/src/hetzner-multimodal.test.ts
+++ b/packages/providers/src/hetzner-multimodal.test.ts
@@ -220,6 +220,74 @@ describe("HetznerMultimodalJudgeProvider", () => {
     expect(JSON.stringify(result)).not.toContain("private malformed output");
   });
 
+  it("gives repair a content-free explanation of invalid not-evaluable bindings", async () => {
+    const invalid = structuredClone(validCandidate());
+    invalid.recommendation = "review_required";
+    invalid.privateReason = "stored_criteria_not_fully_supported";
+    invalid.questionEvaluations[0]!.criterionResults =
+      invalid.questionEvaluations[0]!.criterionResults.map((criterion) => ({
+        ...criterion,
+        result: "not_evaluable" as const,
+        supportedPatchAnchorIds: [],
+        reason: "patch_evidence_supports_criterion" as const,
+      }));
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(completionResponse(invalid))
+      .mockResolvedValueOnce(completionResponse(validCandidate()));
+
+    const result = await providerWith(fetchImpl).evaluate(
+      { ...inputFixture(), frames: [] },
+      contextFixture(),
+    );
+
+    expect(result.metadata).toMatchObject({
+      invocationCount: 2,
+      outcome: "repaired",
+    });
+    const initialBody = String(fetchImpl.mock.calls[0]?.[1]?.body);
+    const repairBody = String(fetchImpl.mock.calls[1]?.[1]?.body);
+    expect(initialBody).toContain("Never attach an anchor to not_evaluable");
+    expect(repairBody).toContain("not_evaluable_reason_mismatch");
+    expect(repairBody).not.toContain(JSON.stringify(invalid));
+  });
+
+  it("reports both failed semantic invocations with safe validation diagnostics", async () => {
+    const invalid = structuredClone(validCandidate());
+    invalid.recommendation = "review_required";
+    invalid.privateReason = "stored_criteria_not_fully_supported";
+    invalid.questionEvaluations[0]!.criterionResults =
+      invalid.questionEvaluations[0]!.criterionResults.map((criterion) => ({
+        ...criterion,
+        result: "not_evaluable" as const,
+        supportedPatchAnchorIds: ["a0"],
+        reason: "patch_evidence_supports_criterion" as const,
+      }));
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockImplementation(async () => completionResponse(invalid));
+
+    await expect(
+      providerWith(fetchImpl).evaluate(
+        { ...inputFixture(), frames: [] },
+        contextFixture(),
+      ),
+    ).rejects.toMatchObject({
+      code: "INVALID_OUTPUT",
+      disposition: "review",
+      telemetry: {
+        lastFailureKind: "invalid_output",
+        transportAttemptCount: 2,
+      },
+      validationCode: "binding_invalid",
+      validationIssueCodes: expect.arrayContaining([
+        "not_evaluable_with_anchor",
+        "not_evaluable_reason_mismatch",
+      ]),
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
   it.each([
     {
       name: "unknown question",

--- a/packages/providers/src/hetzner-multimodal.ts
+++ b/packages/providers/src/hetzner-multimodal.ts
@@ -8,6 +8,8 @@ import {
   safeHttpStatus,
   type ProviderFailureTelemetry,
   type ProviderHttpStatusClass,
+  type ProviderValidationCode,
+  type ProviderValidationIssueCode,
 } from "./errors";
 import { ProviderContextV1Schema, type ProviderContextV1 } from "./contracts";
 import { JudgeEvaluateFailureDiagnosticsV1Schema } from "./judge-diagnostics";
@@ -430,9 +432,6 @@ type RetryableFailure = {
   httpStatusClass?: ProviderHttpStatusClass;
 };
 
-type CandidateValidationCode =
-  "schema_invalid" | "binding_invalid" | "content_policy_invalid";
-
 type TokenUsage = {
   inputTokens: number;
   outputTokens: number;
@@ -562,9 +561,11 @@ export class HetznerMultimodalJudgeProvider implements InlineMultimodalJudgeProv
       );
     } catch (error) {
       if (!(error instanceof CandidateValidationError)) {
-        throw invalidOutputError();
+        throw invalidOutputError(invocationCount);
       }
-      if (invocationCount === 2) throw invalidOutputError();
+      if (invocationCount === 2) {
+        throw invalidOutputError(invocationCount, error);
+      }
       invocationCount = 2;
       const repaired = await this.invoke(
         input.data,
@@ -572,6 +573,7 @@ export class HetznerMultimodalJudgeProvider implements InlineMultimodalJudgeProv
         actualModel,
         {
           validationCode: error.validationCode,
+          validationIssueCodes: error.validationIssueCodes,
           invalidOutputHash: hashUnknown(initial.output),
           maximumAdditionalAttempts: 1,
         },
@@ -582,8 +584,11 @@ export class HetznerMultimodalJudgeProvider implements InlineMultimodalJudgeProv
           repaired.output,
           input.data,
         );
-      } catch {
-        throw invalidOutputError();
+      } catch (error) {
+        throw invalidOutputError(
+          invocationCount,
+          error instanceof CandidateValidationError ? error : undefined,
+        );
       }
       outcome = "repaired";
     }
@@ -615,7 +620,8 @@ export class HetznerMultimodalJudgeProvider implements InlineMultimodalJudgeProv
     deadlineAt: Date,
     model: string,
     repair?: {
-      validationCode: CandidateValidationCode;
+      validationCode: ProviderValidationCode;
+      validationIssueCodes: readonly ProviderValidationIssueCode[];
       invalidOutputHash: string;
       maximumAdditionalAttempts: 1;
     },
@@ -689,8 +695,9 @@ export function validateMultimodalJudgeCandidateV1(
   const candidate = MultimodalJudgeCandidateV1Schema.safeParse(rawCandidate);
   const input = MultimodalJudgeProviderInputV1Schema.safeParse(rawInput);
   if (!candidate.success || !input.success) {
-    throw new CandidateValidationError("schema_invalid");
+    throw new CandidateValidationError("schema_invalid", ["schema_invalid"]);
   }
+  const issues = new Set<ProviderValidationIssueCode>();
   const questions = new Map(
     input.data.questions.map((question) => [question.id, question]),
   );
@@ -698,8 +705,12 @@ export function validateMultimodalJudgeCandidateV1(
   let hasNonPassingResult = false;
   for (const evaluation of candidate.data.questionEvaluations) {
     const question = questions.get(evaluation.questionId);
-    if (question === undefined || seenQuestions.has(evaluation.questionId)) {
-      throw new CandidateValidationError("binding_invalid");
+    if (question === undefined) {
+      issues.add("unknown_question");
+      continue;
+    }
+    if (seenQuestions.has(evaluation.questionId)) {
+      issues.add("duplicate_question");
     }
     seenQuestions.add(evaluation.questionId);
     const expectedCriteria = new Set(
@@ -707,43 +718,55 @@ export function validateMultimodalJudgeCandidateV1(
     );
     const seenCriteria = new Set<string>();
     for (const result of evaluation.criterionResults) {
+      if (!expectedCriteria.has(result.criterionId)) {
+        issues.add("unknown_criterion");
+      }
+      if (seenCriteria.has(result.criterionId)) {
+        issues.add("duplicate_criterion");
+      }
       if (
-        !expectedCriteria.has(result.criterionId) ||
-        seenCriteria.has(result.criterionId) ||
         result.supportedPatchAnchorIds.some(
           (anchorId) => !question.patchAnchorIds.includes(anchorId),
-        ) ||
-        (result.result !== "not_evaluable" &&
-          result.supportedPatchAnchorIds.length === 0) ||
-        (result.result === "not_evaluable" &&
-          result.supportedPatchAnchorIds.length !== 0) ||
+        )
+      ) {
+        issues.add("foreign_anchor");
+      }
+      if (
+        result.result !== "not_evaluable" &&
+        result.supportedPatchAnchorIds.length === 0
+      ) {
+        issues.add("evaluable_without_anchor");
+      }
+      if (
+        result.result === "not_evaluable" &&
+        result.supportedPatchAnchorIds.length !== 0
+      ) {
+        issues.add("not_evaluable_with_anchor");
+      }
+      if (
         (result.result === "met" &&
           result.reason !== "patch_evidence_supports_criterion") ||
         (result.result === "not_met" &&
-          result.reason !== "patch_evidence_conflicts_with_criterion") ||
-        (result.result === "not_evaluable" &&
-          result.reason !== "question_evidence_insufficient" &&
-          result.reason !== "question_evidence_unavailable")
+          result.reason !== "patch_evidence_conflicts_with_criterion")
       ) {
-        throw new CandidateValidationError("binding_invalid");
+        issues.add("result_reason_mismatch");
+      }
+      if (
+        result.result === "not_evaluable" &&
+        result.reason !== "question_evidence_insufficient" &&
+        result.reason !== "question_evidence_unavailable"
+      ) {
+        issues.add("not_evaluable_reason_mismatch");
       }
       seenCriteria.add(result.criterionId);
       if (result.result !== "met") hasNonPassingResult = true;
     }
-    if (
-      seenCriteria.size !== expectedCriteria.size ||
-      [...expectedCriteria].some(
-        (criterionId) => !seenCriteria.has(criterionId),
-      )
-    ) {
-      throw new CandidateValidationError("binding_invalid");
+    for (const criterionId of expectedCriteria) {
+      if (!seenCriteria.has(criterionId)) issues.add("missing_criterion");
     }
   }
-  if (
-    seenQuestions.size !== questions.size ||
-    [...questions.keys()].some((questionId) => !seenQuestions.has(questionId))
-  ) {
-    throw new CandidateValidationError("binding_invalid");
+  for (const questionId of questions.keys()) {
+    if (!seenQuestions.has(questionId)) issues.add("missing_question");
   }
   const hasUnresolvedEvidence = candidate.data.questionEvaluations.some(
     (evaluation) =>
@@ -753,7 +776,10 @@ export function validateMultimodalJudgeCandidateV1(
     candidate.data.recommendation === "pass" &&
     (hasNonPassingResult || hasUnresolvedEvidence)
   ) {
-    throw new CandidateValidationError("binding_invalid");
+    issues.add("pass_with_unresolved_or_nonpassing");
+  }
+  if (issues.size > 0) {
+    throw new CandidateValidationError("binding_invalid", [...issues]);
   }
   return candidate.data;
 }
@@ -900,7 +926,9 @@ export const PROOF_JUDGE_SYSTEM_V2 = [
   "Never identify or characterize a person. Never analyze identity, gaze as identity, disability, or authorship. Do not describe a face, age, gender, race, or who the speaker is.",
   "Never invoke tools or browse. Cite only supplied anchor IDs.",
   "Return every supplied question ID and every criterion ID exactly once; do not add, omit or rewrite criteria.",
-  "Use not_evaluable when evidence is missing or uncertain. A recommendation never makes the public decision; maintainer review remains mandatory.",
+  "For met use one or more anchors from that question and reason patch_evidence_supports_criterion. For not_met use one or more anchors from that question and reason patch_evidence_conflicts_with_criterion.",
+  "For not_evaluable use no anchors and reason question_evidence_insufficient or question_evidence_unavailable. Never attach an anchor to not_evaluable.",
+  "Recommend pass only when every criterion is met and contradictions and uncertainty are both empty. A recommendation never makes the public decision; maintainer review remains mandatory.",
   'Return only one JSON object under the single key "result".',
 ].join(" ");
 
@@ -909,7 +937,8 @@ function buildRequestBody(
   model: string,
   provider: string,
   repair?: {
-    validationCode: CandidateValidationCode;
+    validationCode: ProviderValidationCode;
+    validationIssueCodes: readonly ProviderValidationIssueCode[];
     invalidOutputHash: string;
     maximumAdditionalAttempts: 1;
   },
@@ -1363,9 +1392,17 @@ function isSafeProviderBaseUrl(value: string): boolean {
 }
 
 class CandidateValidationError extends Error {
-  constructor(readonly validationCode: CandidateValidationCode) {
+  readonly validationIssueCodes: readonly ProviderValidationIssueCode[];
+
+  constructor(
+    readonly validationCode: ProviderValidationCode,
+    validationIssueCodes: readonly ProviderValidationIssueCode[],
+  ) {
     super("Multimodal candidate failed its exact server contract");
     this.name = "CandidateValidationError";
+    this.validationIssueCodes = Object.freeze([
+      ...new Set(validationIssueCodes),
+    ]);
   }
 }
 
@@ -1421,11 +1458,28 @@ function invalidInputError(): ProviderError {
   );
 }
 
-function invalidOutputError(): ProviderError {
+function invalidOutputError(
+  invocationCount = 1,
+  validation?: CandidateValidationError,
+): ProviderError {
   return new ProviderError(
     "INVALID_OUTPUT",
     "review",
     "Multimodal provider output is invalid",
+    {
+      ...(validation === undefined ? {} : { cause: validation }),
+      telemetry: {
+        lastFailureKind: "invalid_output",
+        httpStatusClass: null,
+        transportAttemptCount: invocationCount,
+      },
+      ...(validation === undefined
+        ? {}
+        : {
+            validationCode: validation.validationCode,
+            validationIssueCodes: validation.validationIssueCodes,
+          }),
+    },
   );
 }
 

--- a/packages/providers/src/judge-diagnostics.test.ts
+++ b/packages/providers/src/judge-diagnostics.test.ts
@@ -58,4 +58,45 @@ describe("judge evaluate failure diagnostics", () => {
       invocationCount: 1,
     });
   });
+
+  it("keeps safe binding diagnostics and the real generate plus repair count", () => {
+    const diagnostics = describeJudgeEvaluateFailure(
+      new ProviderError(
+        "INVALID_OUTPUT",
+        "review",
+        "private provider output must not cross this boundary",
+        {
+          telemetry: {
+            lastFailureKind: "invalid_output",
+            httpStatusClass: null,
+            transportAttemptCount: 2,
+          },
+          validationCode: "binding_invalid",
+          validationIssueCodes: [
+            "not_evaluable_with_anchor",
+            "not_evaluable_reason_mismatch",
+          ],
+        },
+      ),
+      { hopUsed: "primary", latencyMs: 31_534, frameCount: 1 },
+    );
+
+    expect(diagnostics).toMatchObject({
+      errorCode: "INVALID_OUTPUT",
+      disposition: "review",
+      lastFailureKind: "invalid_output",
+      validationCode: "binding_invalid",
+      validationIssueCodes: [
+        "not_evaluable_with_anchor",
+        "not_evaluable_reason_mismatch",
+      ],
+      hopUsed: "primary",
+      invocationCount: 2,
+      latencyMs: 31_534,
+      frameCount: 1,
+    });
+    expect(JSON.stringify(diagnostics)).not.toContain(
+      "private provider output",
+    );
+  });
 });

--- a/packages/providers/src/judge-diagnostics.ts
+++ b/packages/providers/src/judge-diagnostics.ts
@@ -3,6 +3,8 @@ import {
   JUDGE_HOP_USED,
   PROVIDER_ERROR_CODES,
   PROVIDER_FAILURE_KINDS,
+  PROVIDER_VALIDATION_CODES,
+  PROVIDER_VALIDATION_ISSUE_CODES,
   ProviderError,
   safeHttpStatus,
   type JudgeHopUsed,
@@ -20,6 +22,11 @@ export const JudgeEvaluateFailureDiagnosticsV1Schema = z
     errorCode: z.enum(PROVIDER_ERROR_CODES).optional(),
     disposition: z.enum(["retryable", "terminal", "review"]).optional(),
     lastFailureKind: z.enum(PROVIDER_FAILURE_KINDS).optional(),
+    validationCode: z.enum(PROVIDER_VALIDATION_CODES).optional(),
+    validationIssueCodes: z
+      .array(z.enum(PROVIDER_VALIDATION_ISSUE_CODES))
+      .max(16)
+      .optional(),
     hopUsed: JudgeHopUsedSchema,
     invocationCount: z.union([z.literal(0), z.literal(1), z.literal(2)]),
     latencyMs: z
@@ -45,6 +52,12 @@ export function annotateProviderErrorHopUsed(
     cause: error,
     hopUsed,
     ...(error.telemetry === undefined ? {} : { telemetry: error.telemetry }),
+    ...(error.validationCode === undefined
+      ? {}
+      : { validationCode: error.validationCode }),
+    ...(error.validationIssueCodes === undefined
+      ? {}
+      : { validationIssueCodes: error.validationIssueCodes }),
   });
 }
 
@@ -72,8 +85,14 @@ export function describeJudgeEvaluateFailure(
       ...(error.telemetry === undefined
         ? {}
         : { lastFailureKind: error.telemetry.lastFailureKind }),
+      ...(error.validationCode === undefined
+        ? {}
+        : { validationCode: error.validationCode }),
+      ...(error.validationIssueCodes === undefined
+        ? {}
+        : { validationIssueCodes: error.validationIssueCodes }),
       hopUsed,
-      invocationCount: invocationCountForFailure(hopUsed),
+      invocationCount: invocationCountForFailure(error, hopUsed),
       latencyMs,
       frameCount,
     });
@@ -87,7 +106,12 @@ export function describeJudgeEvaluateFailure(
   });
 }
 
-function invocationCountForFailure(hopUsed: JudgeHopUsed): 0 | 1 | 2 {
+function invocationCountForFailure(
+  error: ProviderError,
+  hopUsed: JudgeHopUsed,
+): 0 | 1 | 2 {
+  const reported = error.telemetry?.transportAttemptCount;
+  if (reported === 0 || reported === 1 || reported === 2) return reported;
   return hopUsed === "transport_fallback" ? 2 : 1;
 }
 
@@ -97,6 +121,8 @@ export type JudgeEvaluateFailureSummary = {
   errorCode?: ProviderErrorCode;
   disposition?: ProviderErrorDisposition;
   lastFailureKind?: ProviderFailureKind;
+  validationCode?: JudgeEvaluateFailureDiagnosticsV1["validationCode"];
+  validationIssueCodes?: JudgeEvaluateFailureDiagnosticsV1["validationIssueCodes"];
   hopUsed: JudgeHopUsed;
   invocationCount: 0 | 1 | 2;
   latencyMs: number;
@@ -120,6 +146,12 @@ export function judgeFailureLogFields(
     ...(diagnostics.lastFailureKind === undefined
       ? {}
       : { lastFailureKind: diagnostics.lastFailureKind }),
+    ...(diagnostics.validationCode === undefined
+      ? {}
+      : { validationCode: diagnostics.validationCode }),
+    ...(diagnostics.validationIssueCodes === undefined
+      ? {}
+      : { validationIssueCodes: diagnostics.validationIssueCodes }),
     hopUsed: diagnostics.hopUsed,
     invocationCount: diagnostics.invocationCount,
     latencyMs: diagnostics.latencyMs,


### PR DESCRIPTION
## Summary

- keep the OAuth-rotated session and CSRF cookie pair coherent across the GitHub redirect chain, while retaining the mandatory same-origin CSRF header
- distinguish capability-auth failures from interrupted video transfers and emit safe status/error enums for future diagnosis
- teach the multimodal judge the exact result/reason/anchor binding rules and pass bounded validation issue codes into its single repair attempt
- preserve privacy by keeping provider content, transcripts, frames, tokens, and raw errors out of diagnostics

## Root cause

The review recording never reached capability issuance. The session cookie was `SameSite=Lax`, while the rotated CSRF cookie was `SameSite=Strict`; after GitHub OAuth this could leave Safari/WebKit with a stale session/CSRF pair and fail `requireMutationSession` before capability audit or streaming.

The judge received HTTP 200 and schema-valid JSON from MiMo, but the candidate violated SlopProof's stricter result/reason/anchor binding. The generic `binding_invalid` repair signal did not tell the model which bounded rule it had violated, so the repair failed too. A Qwen hop correctly did not occur because this was not a transport failure.

## Verification

- `pnpm verify` under Node.js 24: 103 test files / 866 tests passed, plus builds, production contracts, boundary checks, and secret/history audits
- read-only live replay with the same private production input: the updated prompt produced a validator-accepted MiMo evaluation on the first invocation
- no private production evidence or model output is included in this PR

## Rollout note

Existing judge sidecars are immutable. After deployment, re-authorize the maintainer session and create a fresh proof to validate both video playback and the LLM judge end to end.
