### PR TITLE
fix: make proof question preparation total

### DIFF
--- a/apps/web/app/revisions/[revisionId]/contribute/contributor-preparation-state.test.ts
+++ b/apps/web/app/revisions/[revisionId]/contribute/contributor-preparation-state.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { contributorPreparationState } from "./contributor-preparation-state";
+
+describe("contributor preparation state", () => {
+  it("shows ready only after a bounded question budget exists", () => {
+    expect(
+      contributorPreparationState({
+        questionBudget: 4,
+        checkStatus: "in_progress",
+        checkConclusion: null,
+        checkReason: "analysis_ready",
+      }),
+    ).toBe("ready");
+  });
+
+  it("shows a terminal system failure without turning it into a 404", () => {
+    expect(
+      contributorPreparationState({
+        questionBudget: null,
+        checkStatus: "completed",
+        checkConclusion: "action_required",
+        checkReason: "preparation_failed",
+      }),
+    ).toBe("failed");
+  });
+
+  it("keeps a revision without a budget in preparing", () => {
+    expect(
+      contributorPreparationState({
+        questionBudget: null,
+        checkStatus: "in_progress",
+        checkConclusion: null,
+        checkReason: "webhook_ingested",
+      }),
+    ).toBe("preparing");
+  });
+});

--- a/apps/web/app/revisions/[revisionId]/contribute/contributor-preparation-state.ts
+++ b/apps/web/app/revisions/[revisionId]/contribute/contributor-preparation-state.ts
@@ -1,0 +1,26 @@
+export type ContributorPreparationState = "preparing" | "ready" | "failed";
+
+export function contributorPreparationState(input: {
+  questionBudget: number | null;
+  checkStatus: "queued" | "in_progress" | "completed";
+  checkConclusion:
+    "action_required" | "success" | "neutral" | "cancelled" | null;
+  checkReason: string | null;
+}): ContributorPreparationState {
+  if (
+    Number.isInteger(input.questionBudget) &&
+    input.questionBudget !== null &&
+    input.questionBudget >= 1 &&
+    input.questionBudget <= 5
+  ) {
+    return "ready";
+  }
+  if (
+    input.checkStatus === "completed" &&
+    input.checkConclusion === "action_required" &&
+    input.checkReason === "preparation_failed"
+  ) {
+    return "failed";
+  }
+  return "preparing";
+}

--- a/apps/web/app/revisions/[revisionId]/contribute/page.tsx
+++ b/apps/web/app/revisions/[revisionId]/contribute/page.tsx
@@ -4,6 +4,7 @@ import { RetryAttempt } from "../../../retry-attempt";
 import { ProofHandoff } from "../../../demo/pr/[number]/proof-handoff";
 import { readPageSession } from "../../../../lib/http-auth";
 import { getWebRuntime } from "../../../../lib/runtime";
+import { contributorPreparationState } from "./contributor-preparation-state";
 
 export const dynamic = "force-dynamic";
 
@@ -15,7 +16,12 @@ type ContributorView = {
   is_current: boolean;
   attempt_id: string | null;
   status: string | null;
-  question_budget: number;
+  question_budget: number | null;
+  check_status: "queued" | "in_progress" | "completed";
+  check_conclusion:
+    "action_required" | "success" | "neutral" | "cancelled" | null;
+  check_reason: string | null;
+  public_summary: string;
   risk_explanation: null | {
     title?: string;
     riskLevel?: string;
@@ -54,10 +60,15 @@ export default async function ContributorPage({
             attempt.id AS attempt_id, attempt.status,
             COALESCE(proof_plan.question_budget, semantic_budget.question_budget)
               AS question_budget,
-            proof_plan.risk_explanation
+            proof_plan.risk_explanation,
+            check_run.status AS check_status,
+            check_run.conclusion AS check_conclusion,
+            check_run.intent_reason AS check_reason,
+            check_run.public_summary
      FROM pull_request_revisions revision
      JOIN pull_requests pull_request ON pull_request.id = revision.pull_request_id
      JOIN repositories repository ON repository.id = pull_request.repository_id
+     JOIN check_runs check_run ON check_run.revision_id = revision.id
      LEFT JOIN LATERAL (
        SELECT candidate.* FROM attempts candidate
        WHERE candidate.revision_id = revision.id
@@ -86,7 +97,13 @@ export default async function ContributorPage({
     ],
   );
   const view = result.rows[0];
-  if (!view || !Number.isInteger(view.question_budget)) notFound();
+  if (!view) notFound();
+  const preparationState = contributorPreparationState({
+    questionBudget: view.question_budget,
+    checkStatus: view.check_status,
+    checkConclusion: view.check_conclusion,
+    checkReason: view.check_reason,
+  });
   const attemptStatus = view.status ?? "preparing";
 
   return (
@@ -115,6 +132,24 @@ export default async function ContributorPage({
         <section className="notice-card">
           This revision is historical. Open the check for the current head SHA
           before creating another proof.
+        </section>
+      ) : preparationState === "failed" ? (
+        <section className="notice-card">
+          <h2>Proof preparation failed.</h2>
+          <p>{view.public_summary}</p>
+          <p>
+            This is a SlopProof system failure, not a contributor result. The
+            required check stays closed until a maintainer retries a repaired
+            pipeline.
+          </p>
+        </section>
+      ) : preparationState === "preparing" ? (
+        <section className="notice-card">
+          <h2>Preparing patch-bound questions.</h2>
+          <p>
+            SlopProof is still analyzing this exact revision. Refresh this page
+            after the GitHub check advances; no proof attempt has started.
+          </p>
         </section>
       ) : (
         <div className="choice-grid">

--- a/apps/web/app/revisions/[revisionId]/page.tsx
+++ b/apps/web/app/revisions/[revisionId]/page.tsx
@@ -16,6 +16,7 @@ type PublicRevision = {
   conclusion: "action_required" | "success" | "neutral" | "cancelled" | null;
   public_summary: string;
   has_attempt: boolean;
+  has_preparation_budget: boolean;
 };
 
 export default async function PublicRevisionPage({
@@ -37,7 +38,12 @@ export default async function PublicRevisionPage({
             EXISTS (
               SELECT 1 FROM attempts attempt
               WHERE attempt.revision_id = revision.id
-            ) AS has_attempt
+            ) AS has_attempt,
+            EXISTS (
+              SELECT 1 FROM semantic_generation_budgets budget
+              WHERE budget.revision_id = revision.id
+                AND budget.head_sha = revision.head_sha
+            ) AS has_preparation_budget
      FROM pull_request_revisions revision
      JOIN pull_requests pull_request ON pull_request.id = revision.pull_request_id
      JOIN repositories repository ON repository.id = pull_request.repository_id
@@ -52,6 +58,8 @@ export default async function PublicRevisionPage({
     isCurrent: revision.is_current,
     conclusion: revision.conclusion,
     hasAttempt: revision.has_attempt,
+    preparationAvailable:
+      revision.has_preparation_budget || revision.has_attempt,
   });
 
   return (

--- a/apps/web/app/revisions/[revisionId]/public-check-ctas.test.ts
+++ b/apps/web/app/revisions/[revisionId]/public-check-ctas.test.ts
@@ -8,6 +8,7 @@ describe("public check CTAs", () => {
         isCurrent: true,
         conclusion: null,
         hasAttempt: false,
+        preparationAvailable: true,
       }),
     ).toEqual({ showContributor: true, showMaintainer: false });
   });
@@ -18,6 +19,7 @@ describe("public check CTAs", () => {
         isCurrent: true,
         conclusion: "action_required",
         hasAttempt: true,
+        preparationAvailable: true,
       }),
     ).toEqual({ showContributor: true, showMaintainer: true });
   });
@@ -28,6 +30,7 @@ describe("public check CTAs", () => {
         isCurrent: false,
         conclusion: "neutral",
         hasAttempt: true,
+        preparationAvailable: true,
       }),
     ).toEqual({ showContributor: false, showMaintainer: true });
     expect(
@@ -35,6 +38,7 @@ describe("public check CTAs", () => {
         isCurrent: false,
         conclusion: null,
         hasAttempt: false,
+        preparationAvailable: false,
       }),
     ).toEqual({ showContributor: false, showMaintainer: false });
   });
@@ -45,6 +49,7 @@ describe("public check CTAs", () => {
         isCurrent: true,
         conclusion: "success",
         hasAttempt: true,
+        preparationAvailable: true,
       }),
     ).toEqual({ showContributor: false, showMaintainer: true });
     expect(
@@ -52,6 +57,18 @@ describe("public check CTAs", () => {
         isCurrent: true,
         conclusion: "cancelled",
         hasAttempt: false,
+        preparationAvailable: true,
+      }),
+    ).toEqual({ showContributor: false, showMaintainer: false });
+  });
+
+  it("does not expose contributor flow before preparation has a budget", () => {
+    expect(
+      publicCheckCtas({
+        isCurrent: true,
+        conclusion: null,
+        hasAttempt: false,
+        preparationAvailable: false,
       }),
     ).toEqual({ showContributor: false, showMaintainer: false });
   });

--- a/apps/web/app/revisions/[revisionId]/public-check-ctas.ts
+++ b/apps/web/app/revisions/[revisionId]/public-check-ctas.ts
@@ -5,10 +5,13 @@ export function publicCheckCtas(input: {
   isCurrent: boolean;
   conclusion: PublicCheckConclusion;
   hasAttempt: boolean;
+  preparationAvailable: boolean;
 }): { showContributor: boolean; showMaintainer: boolean } {
   return {
     showContributor:
-      input.isCurrent && revisionRequiresUnderstanding(input.conclusion),
+      input.isCurrent &&
+      input.preparationAvailable &&
+      revisionRequiresUnderstanding(input.conclusion),
     showMaintainer: input.hasAttempt,
   };
 }

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -30,7 +30,7 @@ import { PostgresGithubRevisionPatchSource } from "./github-revision-patch-sourc
 import {
   createWorkerCheckIntentWriter,
   LocalFakeRevisionPatchSource,
-  prepareRevision,
+  prepareRevisionFailClosed,
 } from "./revision-preparation";
 import { createPostgresRetentionService } from "./retention";
 import { handleReviewContextRequest } from "./review-context";
@@ -220,7 +220,7 @@ async function start(): Promise<void> {
     activeJobQueue,
     "analysis.prepare-revision",
     async (job) => {
-      await prepareRevision(job.data, {
+      const result = await prepareRevisionFailClosed(job.data, {
         pool: database.pool,
         queue: activeJobQueue,
         checkIntents,
@@ -228,6 +228,15 @@ async function start(): Promise<void> {
         generationContexts,
         semanticGeneration: activeSemanticRepository,
       });
+      if (result.outcome === "preparation_failed") {
+        log.error(
+          {
+            revisionId: result.revisionId,
+            headSha: result.headSha,
+          },
+          "analysis.preparation_failed",
+        );
+      }
     },
   );
   await registerJobWorker(

--- a/apps/worker/src/revision-preparation.ts
+++ b/apps/worker/src/revision-preparation.ts
@@ -28,7 +28,11 @@ import {
   RepositoryPolicyV1Schema,
   type RepositoryPolicyV1,
 } from "@slopproof/policy";
-import { planProof, type ProofQuestion } from "@slopproof/questions";
+import {
+  planProof,
+  planProofBudget,
+  type ProofQuestion,
+} from "@slopproof/questions";
 import type { Pool, PoolClient } from "pg";
 import type { PgBoss } from "pg-boss";
 
@@ -51,6 +55,7 @@ export type WorkerCheckIntentWriterInput = {
   summary: string;
   reason:
     | "analysis_ready"
+    | "preparation_failed"
     | "review_required"
     | "technical_retry"
     | "attempt_expired";
@@ -225,6 +230,11 @@ export type PrepareRevisionDependencies = {
 export type PrepareRevisionResult =
   | { outcome: "stale" | "closed" | "split_recommended" }
   | {
+      outcome: "preparation_failed";
+      revisionId: string;
+      headSha: string;
+    }
+  | {
       outcome: "semantic_generation_queued" | "semantic_generation_replayed";
       revisionId: string;
       headSha: string;
@@ -300,20 +310,7 @@ export async function prepareRevision(
     throw new Error("Patch source returned data for a different revision");
   }
   const analysis = analyzePullRequestPatch(patch);
-  const proof = planProof(
-    {
-      analysis,
-      policy,
-      serverSeed: sha256(
-        `proof-plan:${context.revision_id}:${context.head_sha}`,
-      ),
-      versions: {
-        planner: "proof-planner-v1",
-        questionTemplates: "proof-questions-v1",
-      },
-    },
-    { clock: { now: () => context.received_at } },
-  );
+  const proofBudget = planProofBudget({ analysis, policy });
   const diffHash = sha256(JSON.stringify(patch));
   const now = dependencies.clock?.now() ?? new Date();
   const client = await dependencies.pool.connect();
@@ -376,7 +373,7 @@ export async function prepareRevision(
       throw new Error("Generation context persistence returned no identity");
     }
 
-    if (proof.status === "split_recommended") {
+    if (proofBudget.status === "split_recommended") {
       await dependencies.checkIntents.write(client, {
         revisionId: current.revision_id,
         headSha: current.head_sha,
@@ -405,7 +402,7 @@ export async function prepareRevision(
             generationContextId: persistedGenerationContext.id,
             repositoryPolicyId: frozenPolicyId,
             headSha: current.head_sha,
-            questionBudget: proof.questionBudget,
+            questionBudget: proofBudget.questionBudget,
           },
         );
       if (scheduled === "created") {
@@ -433,7 +430,7 @@ export async function prepareRevision(
             JSON.stringify({
               headSha: current.head_sha,
               generationContextId: persistedGenerationContext.id,
-              questionBudget: proof.questionBudget,
+              questionBudget: proofBudget.questionBudget,
             }),
           ],
         );
@@ -450,6 +447,20 @@ export async function prepareRevision(
       };
     }
 
+    const proof = planProof(
+      {
+        analysis,
+        policy,
+        serverSeed: sha256(
+          `proof-plan:${context.revision_id}:${context.head_sha}`,
+        ),
+        versions: {
+          planner: "proof-planner-v1",
+          questionTemplates: "proof-questions-v1",
+        },
+      },
+      { clock: { now: () => context.received_at } },
+    );
     await client.query(
       `INSERT INTO proof_plans
         (id, revision_id, generation_context_id, repository_policy_id, plan_version,
@@ -610,6 +621,163 @@ export async function prepareRevision(
   } finally {
     client.release();
   }
+}
+
+/**
+ * Job boundary for deterministic preparation failures. Infrastructure errors
+ * remain retryable; a content/schema/programming failure is persisted once as
+ * a fail-closed Check result instead of exhausting the queue invisibly.
+ */
+export async function prepareRevisionFailClosed(
+  rawPayload: JobPayload<"analysis.prepare-revision">,
+  dependencies: PrepareRevisionDependencies,
+): Promise<PrepareRevisionResult> {
+  const payload = parseJobPayload("analysis.prepare-revision", rawPayload);
+  try {
+    return await prepareRevision(payload, dependencies);
+  } catch (error) {
+    if (isRetryablePreparationError(error)) throw error;
+    return persistPreparationFailure(payload, dependencies, error);
+  }
+}
+
+async function persistPreparationFailure(
+  payload: JobPayload<"analysis.prepare-revision">,
+  dependencies: Pick<PrepareRevisionDependencies, "pool" | "checkIntents">,
+  error: unknown,
+): Promise<PrepareRevisionResult> {
+  const client = await dependencies.pool.connect();
+  try {
+    await client.query("BEGIN");
+    const revision = await client.query<{
+      head_sha: string;
+      is_current: boolean;
+      pull_request_state: string;
+    }>(
+      `SELECT revision.head_sha, revision.is_current,
+              pull_request.state AS pull_request_state
+         FROM pull_request_revisions revision
+         JOIN pull_requests pull_request
+           ON pull_request.id = revision.pull_request_id
+        WHERE revision.id = $1
+        FOR UPDATE OF revision, pull_request`,
+      [payload.revisionId],
+    );
+    const current = revision.rows[0];
+    if (
+      current === undefined ||
+      !current.is_current ||
+      current.head_sha !== payload.expectedHeadSha
+    ) {
+      await client.query("ROLLBACK");
+      return { outcome: "stale" };
+    }
+    if (current.pull_request_state !== "open") {
+      await client.query("ROLLBACK");
+      return { outcome: "closed" };
+    }
+    await dependencies.checkIntents.write(client, {
+      revisionId: payload.revisionId,
+      headSha: payload.expectedHeadSha,
+      status: "completed",
+      conclusion: "action_required",
+      summary: `SlopProof could not prepare patch-bound questions for head ${payload.expectedHeadSha}. Maintainer action is required.`,
+      reason: "preparation_failed",
+      idempotencyKey: `analysis-preparation-failed:${payload.revisionId}`,
+    });
+    await client.query(
+      `INSERT INTO audit_events
+         (actor_id, action, object_type, object_id, metadata)
+       SELECT 'analysis-worker', 'analysis.preparation_failed',
+              'revision', $1, $2::jsonb
+       WHERE NOT EXISTS (
+         SELECT 1 FROM audit_events
+          WHERE action = 'analysis.preparation_failed'
+            AND object_type = 'revision' AND object_id = $1
+       )`,
+      [
+        payload.revisionId,
+        JSON.stringify({
+          headSha: payload.expectedHeadSha,
+          errorClass: safeErrorClass(error),
+        }),
+      ],
+    );
+    await client.query("COMMIT");
+    return {
+      outcome: "preparation_failed",
+      revisionId: payload.revisionId,
+      headSha: payload.expectedHeadSha,
+    };
+  } catch (failurePersistenceError) {
+    await client.query("ROLLBACK").catch(() => undefined);
+    throw failurePersistenceError;
+  } finally {
+    client.release();
+  }
+}
+
+const RETRYABLE_ERROR_CODES = new Set([
+  "40001",
+  "40P01",
+  "55P03",
+  "57014",
+  "57P01",
+  "57P02",
+  "57P03",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETDOWN",
+  "ENETUNREACH",
+  "ETIMEDOUT",
+]);
+
+export function isRetryablePreparationError(
+  error: unknown,
+  seen: Set<unknown> = new Set(),
+): boolean {
+  if (typeof error !== "object" || error === null || seen.has(error)) {
+    return false;
+  }
+  seen.add(error);
+  const candidate = error as {
+    name?: unknown;
+    code?: unknown;
+    status?: unknown;
+    cause?: unknown;
+  };
+  if (candidate.name === "AbortError") return true;
+  if (
+    typeof candidate.code === "string" &&
+    (candidate.code.startsWith("08") ||
+      candidate.code.startsWith("53") ||
+      candidate.code.startsWith("58") ||
+      RETRYABLE_ERROR_CODES.has(candidate.code))
+  ) {
+    return true;
+  }
+  if (
+    typeof candidate.status === "number" &&
+    (candidate.status === 408 ||
+      candidate.status === 425 ||
+      candidate.status === 429 ||
+      candidate.status >= 500)
+  ) {
+    return true;
+  }
+  return isRetryablePreparationError(candidate.cause, seen);
+}
+
+export function safeErrorClass(error: unknown): string {
+  if (
+    error instanceof Error &&
+    /^[A-Za-z][A-Za-z0-9_.:-]{0,127}$/u.test(error.name)
+  ) {
+    return error.name;
+  }
+  return "UnknownError";
 }
 
 const REVISION_CONTEXT_SQL = `

--- a/apps/worker/src/semantic-generation-contracts.ts
+++ b/apps/worker/src/semantic-generation-contracts.ts
@@ -145,6 +145,16 @@ export interface SemanticProofReadyWriter {
       idempotencyKey: string;
     },
   ): Promise<void>;
+  fail(
+    client: PoolClient,
+    input: {
+      revisionId: string;
+      generationContextId: string;
+      headSha: string;
+      errorClass: string;
+      idempotencyKey: string;
+    },
+  ): Promise<void>;
 }
 
 export interface SemanticGenerationRepository {
@@ -194,6 +204,10 @@ export interface SemanticGenerationRepository {
     | { outcome: "replayed" | "recovered"; attemptId: string }
     | { outcome: "stale" | "existing_attempt_conflict" }
   >;
+  failProofPreparation(
+    payload: JobPayload<"semantic.generate-proof-questions">,
+    errorClass: string,
+  ): Promise<"failed" | "stale">;
   expirePrivate(
     payload: JobPayload<"semantic.expire-private">,
   ): Promise<"deleted" | "replayed">;

--- a/apps/worker/src/semantic-generation-jobs.test.ts
+++ b/apps/worker/src/semantic-generation-jobs.test.ts
@@ -78,6 +78,52 @@ describe("semantic generation job handlers", () => {
     );
     expect(deadlineAt.getTime() - createdAt.getTime()).toBe(8 * 60_000);
   });
+
+  it("turns a deterministic Proof system error into preparation_failed once", async () => {
+    const failProofPreparation = vi.fn(async () => "failed" as const);
+    const handlers = createSemanticGenerationJobHandlers({
+      repository: repositoryStub({
+        reserveRun: vi.fn(async () =>
+          runFixture({
+            createdAt: new Date("2026-08-19T15:46:12.000Z"),
+            deadlineAt: new Date("2026-08-19T15:54:12.000Z"),
+          }),
+        ),
+        failProofPreparation,
+      }),
+      service: serviceStub({
+        generateProofQuestionPlan: vi.fn(async () => {
+          throw new Error("private deterministic binding failure");
+        }),
+      }),
+    });
+
+    await expect(
+      handlers["semantic.generate-proof-questions"](proofPayload()),
+    ).resolves.toEqual({ outcome: "failed" });
+    expect(failProofPreparation).toHaveBeenCalledWith(proofPayload(), "Error");
+  });
+
+  it("keeps transient Proof infrastructure failures retryable", async () => {
+    const retryable = Object.assign(new Error("serialization retry"), {
+      code: "40001",
+    });
+    const failProofPreparation = vi.fn(async () => "failed" as const);
+    const handlers = createSemanticGenerationJobHandlers({
+      repository: repositoryStub({
+        reserveRun: vi.fn(async () => {
+          throw retryable;
+        }),
+        failProofPreparation,
+      }),
+      service: serviceStub({}),
+    });
+
+    await expect(
+      handlers["semantic.generate-proof-questions"](proofPayload()),
+    ).rejects.toBe(retryable);
+    expect(failProofPreparation).not.toHaveBeenCalled();
+  });
 });
 
 function learningPayload(): JobPayload<"semantic.generate-learning"> {
@@ -85,6 +131,17 @@ function learningPayload(): JobPayload<"semantic.generate-learning"> {
     schemaVersion: "1",
     idempotencyKey: "semantic.learning.v3:82000000-0000-4000-8000-000000000003",
     artifactKind: "learning_bundle_v1",
+    revisionId: "82000000-0000-4000-8000-000000000002",
+    generationContextId: "82000000-0000-4000-8000-000000000003",
+    expectedHeadSha: "a".repeat(40),
+  };
+}
+
+function proofPayload(): JobPayload<"semantic.generate-proof-questions"> {
+  return {
+    schemaVersion: "1",
+    idempotencyKey: "semantic.proof.v2:82000000-0000-4000-8000-000000000003",
+    artifactKind: "proof_question_plan_v2",
     revisionId: "82000000-0000-4000-8000-000000000002",
     generationContextId: "82000000-0000-4000-8000-000000000003",
     expectedHeadSha: "a".repeat(40),
@@ -127,6 +184,7 @@ function repositoryStub(
     persistPracticeFeedback: vi.fn(),
     persistProofPlanAndCreateAttempt: vi.fn(),
     replayCompletedProof: vi.fn(),
+    failProofPreparation: vi.fn(),
     expirePrivate: vi.fn(),
     startPracticeSession: vi.fn(),
     submitPracticeAnswer: vi.fn(),

--- a/apps/worker/src/semantic-generation-jobs.ts
+++ b/apps/worker/src/semantic-generation-jobs.ts
@@ -9,6 +9,10 @@ import type {
   SemanticGenerationJobHandlerDependencies,
   SemanticGenerationJobHandlers,
 } from "./semantic-generation-contracts";
+import {
+  isRetryablePreparationError,
+  safeErrorClass,
+} from "./revision-preparation";
 
 export function createSemanticGenerationJobHandlers(
   dependencies: SemanticGenerationJobHandlerDependencies,
@@ -90,35 +94,45 @@ export function createSemanticGenerationJobHandlers(
     },
 
     async "semantic.generate-proof-questions"(payload) {
-      const run = await dependencies.repository.reserveRun(
-        "semantic.generate-proof-questions",
-        payload,
-      );
-      if (run === "stale") return { outcome: "stale" };
-      if (run === "proof_pending") {
-        throw new Error(
-          "Proof generation does not wait on frozen Proof content.",
+      try {
+        const run = await dependencies.repository.reserveRun(
+          "semantic.generate-proof-questions",
+          payload,
         );
+        if (run === "stale") return { outcome: "stale" };
+        if (run === "proof_pending") {
+          throw new Error(
+            "Proof generation does not wait on frozen Proof content.",
+          );
+        }
+        if (run.completedArtifactId !== null) {
+          return dependencies.repository.replayCompletedProof(run);
+        }
+        const request: GenerateProofQuestionPlanRequestV1 = {
+          schemaVersion: "1",
+          requestVersion: "generate-proof-question-plan-v1",
+          generationContext: run.generationContext,
+          artifactSeed: run.artifactSeed,
+          artifactCreatedAt: run.createdAt,
+          deadlineAt: run.deadlineAt,
+          deleteAfter: run.deleteAfter,
+          questionBudget: run.questionCount,
+        };
+        const result =
+          await dependencies.service.generateProofQuestionPlan(request);
+        return dependencies.repository.persistProofPlanAndCreateAttempt(
+          run,
+          result,
+        );
+      } catch (error) {
+        if (isRetryablePreparationError(error)) throw error;
+        return {
+          outcome: await dependencies.repository.failProofPreparation(
+            payload,
+            safeErrorClass(error),
+          ),
+        };
       }
-      if (run.completedArtifactId !== null) {
-        return dependencies.repository.replayCompletedProof(run);
-      }
-      const request: GenerateProofQuestionPlanRequestV1 = {
-        schemaVersion: "1",
-        requestVersion: "generate-proof-question-plan-v1",
-        generationContext: run.generationContext,
-        artifactSeed: run.artifactSeed,
-        artifactCreatedAt: run.createdAt,
-        deadlineAt: run.deadlineAt,
-        deleteAfter: run.deleteAfter,
-        questionBudget: run.questionCount,
-      };
-      const result =
-        await dependencies.service.generateProofQuestionPlan(request);
-      return dependencies.repository.persistProofPlanAndCreateAttempt(
-        run,
-        result,
-      );
     },
 
     async "semantic.expire-private"(payload) {

--- a/apps/worker/src/semantic-generation-repository.test.ts
+++ b/apps/worker/src/semantic-generation-repository.test.ts
@@ -402,7 +402,10 @@ function schedulerFixture(): SemanticTransactionalScheduler & {
 }
 
 function proofReadyFixture(): SemanticProofReadyWriter {
-  return { write: vi.fn(async () => undefined) };
+  return {
+    write: vi.fn(async () => undefined),
+    fail: vi.fn(async () => undefined),
+  };
 }
 
 function databaseFixture(query: ReturnType<typeof vi.fn>): DatabaseConnection {

--- a/apps/worker/src/semantic-generation-repository.ts
+++ b/apps/worker/src/semantic-generation-repository.ts
@@ -164,13 +164,19 @@ export class PostgresSemanticGenerationRepository implements SemanticGenerationR
         ) AS proof_ready,
         (
           NOT EXISTS (
-            SELECT 1 FROM attempts WHERE revision_id = $1
-          )
-          OR EXISTS (
-            SELECT 1 FROM semantic_generation_runs
-             WHERE generation_context_id = $2
-               AND purpose = 'proof_questions'
-               AND completed_at IS NOT NULL
+            SELECT 1 FROM check_runs check_run
+             WHERE check_run.revision_id = $1
+               AND check_run.intent_reason = 'preparation_failed'
+          ) AND (
+            NOT EXISTS (
+              SELECT 1 FROM attempts WHERE revision_id = $1
+            )
+            OR EXISTS (
+              SELECT 1 FROM semantic_generation_runs
+               WHERE generation_context_id = $2
+                 AND purpose = 'proof_questions'
+                 AND completed_at IS NOT NULL
+            )
           )
         ) AS should_schedule`,
       [input.revisionId, input.generationContextId, input.questionBudget],
@@ -207,6 +213,66 @@ export class PostgresSemanticGenerationRepository implements SemanticGenerationR
       authorId: run.authorId,
       headSha: run.generationContext.headSha,
     });
+  }
+
+  async failProofPreparation(
+    payload: JobPayload<"semantic.generate-proof-questions">,
+    errorClass: string,
+  ): Promise<"failed" | "stale"> {
+    if (!/^[A-Za-z][A-Za-z0-9_.:-]{0,127}$/u.test(errorClass)) {
+      throw new Error("Proof preparation error class is invalid.");
+    }
+    const client = await this.database.pool.connect();
+    try {
+      await client.query("BEGIN");
+      await client.query(
+        "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+        [`semantic-proof:${payload.revisionId}`],
+      );
+      const current = await client.query<{ current: boolean }>(
+        `SELECT (
+            revision.is_current = true
+            AND revision.head_sha = $3
+            AND pull_request.state = 'open'
+            AND budget.generation_context_id = $2
+            AND NOT EXISTS (
+              SELECT 1 FROM attempts attempt
+               WHERE attempt.revision_id = revision.id
+            )
+          ) AS current
+           FROM pull_request_revisions revision
+           JOIN pull_requests pull_request
+             ON pull_request.id = revision.pull_request_id
+           JOIN semantic_generation_budgets budget
+             ON budget.revision_id = revision.id
+            AND budget.head_sha = revision.head_sha
+          WHERE revision.id = $1
+          FOR UPDATE OF revision, pull_request`,
+        [
+          payload.revisionId,
+          payload.generationContextId,
+          payload.expectedHeadSha,
+        ],
+      );
+      if (current.rows[0]?.current !== true) {
+        await client.query("ROLLBACK");
+        return "stale";
+      }
+      await this.proofReady.fail(client, {
+        revisionId: payload.revisionId,
+        generationContextId: payload.generationContextId,
+        headSha: payload.expectedHeadSha,
+        errorClass,
+        idempotencyKey: `semantic-preparation-failed:${payload.generationContextId}`,
+      });
+      await client.query("COMMIT");
+      return "failed";
+    } catch (error) {
+      await client.query("ROLLBACK").catch(() => undefined);
+      throw error;
+    } finally {
+      client.release();
+    }
   }
 
   async reserveRun(
@@ -1659,6 +1725,10 @@ export class PostgresSemanticGenerationRepository implements SemanticGenerationR
                      AND run.completed_at IS NOT NULL
                 ) AS needs_learning,
                 (NOT EXISTS (
+                  SELECT 1 FROM check_runs check_run
+                   WHERE check_run.revision_id = budget.revision_id
+                     AND check_run.intent_reason = 'preparation_failed'
+                ) AND NOT EXISTS (
                   SELECT 1 FROM semantic_generation_runs run
                    WHERE run.generation_context_id = budget.generation_context_id
                      AND run.purpose = 'proof_questions'
@@ -1682,6 +1752,11 @@ export class PostgresSemanticGenerationRepository implements SemanticGenerationR
             AND pull_request.state = 'open'
             AND repository.status = 'active'
             AND installation.status = 'active'
+            AND NOT EXISTS (
+              SELECT 1 FROM check_runs check_run
+               WHERE check_run.revision_id = budget.revision_id
+                 AND check_run.intent_reason = 'preparation_failed'
+            )
             AND (
               NOT EXISTS (
                 SELECT 1 FROM semantic_generation_runs run
@@ -1690,6 +1765,10 @@ export class PostgresSemanticGenerationRepository implements SemanticGenerationR
                    AND run.completed_at IS NOT NULL
               )
               OR (NOT EXISTS (
+                SELECT 1 FROM check_runs check_run
+                 WHERE check_run.revision_id = budget.revision_id
+                   AND check_run.intent_reason = 'preparation_failed'
+              ) AND NOT EXISTS (
                 SELECT 1 FROM semantic_generation_runs run
                  WHERE run.generation_context_id = budget.generation_context_id
                    AND run.purpose = 'proof_questions'
@@ -1922,6 +2001,11 @@ async function loadRunBinding(
         AND revision.head_sha = $3 AND context.head_sha = $3
         AND repository.status = 'active'
         AND installation.status = 'active'
+        AND NOT EXISTS (
+          SELECT 1 FROM check_runs check_run
+           WHERE check_run.revision_id = revision.id
+             AND check_run.intent_reason = 'preparation_failed'
+        )
       FOR SHARE OF revision, context, pull_request, repository, installation`,
     [revisionId, generationContextId, headSha],
   );

--- a/apps/worker/src/semantic-proof-ready.ts
+++ b/apps/worker/src/semantic-proof-ready.ts
@@ -19,7 +19,49 @@ export function createSemanticProofReadyWriter(
       });
       await insertProofReadyAuditOnce(client, input);
     },
+    async fail(client, input) {
+      await checkIntents.write(client, {
+        revisionId: input.revisionId,
+        headSha: input.headSha,
+        status: "completed",
+        conclusion: "action_required",
+        summary: `SlopProof could not prepare patch-bound questions for head ${input.headSha}. Maintainer action is required.`,
+        reason: "preparation_failed",
+        idempotencyKey: input.idempotencyKey,
+      });
+      await insertProofPreparationFailureAuditOnce(client, input);
+    },
   };
+}
+
+async function insertProofPreparationFailureAuditOnce(
+  client: PoolClient,
+  input: {
+    revisionId: string;
+    generationContextId: string;
+    headSha: string;
+    errorClass: string;
+  },
+): Promise<void> {
+  await client.query(
+    `INSERT INTO audit_events
+       (actor_id, action, object_type, object_id, metadata)
+     SELECT 'semantic-worker', 'analysis.preparation_failed',
+            'revision', $1, $2::jsonb
+     WHERE NOT EXISTS (
+       SELECT 1 FROM audit_events
+        WHERE action = 'analysis.preparation_failed'
+          AND object_type = 'revision' AND object_id = $1
+     )`,
+    [
+      input.revisionId,
+      JSON.stringify({
+        headSha: input.headSha,
+        generationContextId: input.generationContextId,
+        errorClass: input.errorClass,
+      }),
+    ],
+  );
 }
 
 async function insertProofReadyAuditOnce(

--- a/packages/db/migrations/0018_revision_preparation_failure.sql
+++ b/packages/db/migrations/0018_revision_preparation_failure.sql
@@ -1,0 +1,2 @@
+ALTER TYPE github_check_intent_reason
+  ADD VALUE IF NOT EXISTS 'preparation_failed';

--- a/packages/db/src/jobs.ts
+++ b/packages/db/src/jobs.ts
@@ -119,6 +119,7 @@ export const GithubReconcileCheckJobSchema = z
     reason: z.enum([
       "webhook_ingested",
       "analysis_ready",
+      "preparation_failed",
       "proof_started",
       "review_required",
       "maintainer_decision",

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -73,6 +73,7 @@ export const githubCheckIntentReasonEnum = pgEnum(
   [
     "webhook_ingested",
     "analysis_ready",
+    "preparation_failed",
     "proof_started",
     "review_required",
     "maintainer_decision",

--- a/packages/questions/src/generative.test.ts
+++ b/packages/questions/src/generative.test.ts
@@ -242,6 +242,24 @@ describe("Gate 4 semantic content contracts", () => {
     ).toBe(true);
   });
 
+  it("keeps a five-question same-file fallback total and collision-free", () => {
+    const context = sameFileContextFixture();
+    const candidates = deterministicProofFallbackV2(context, 5);
+
+    expect(candidates).toHaveLength(5);
+    expect(new Set(candidates.map((candidate) => candidate.prompt)).size).toBe(
+      5,
+    );
+    expect(
+      candidates.every(
+        (candidate) =>
+          candidate.anchorIds.length === 1 &&
+          candidate.patchReferences.length === 1 &&
+          candidate.anchorIds[0] === candidate.patchReferences[0]?.anchorId,
+      ),
+    ).toBe(true);
+  });
+
   it("rejects a 301-character rubric description before a Proof plan can be frozen or hashed", () => {
     const candidate = deterministicProofFallbackV2(contextFixture(), 1)[0];
     expect(candidate).toBeDefined();
@@ -521,6 +539,54 @@ function contextFixture(): GenerationContextV1 {
   return buildGenerationContextV1({
     revisionId: "10000000-0000-4000-8000-000000000001",
     analysisSnapshotId: "10000000-0000-4000-8000-000000000002",
+    boundedSource: bounded,
+    analysis,
+    excerpts: [],
+  });
+}
+
+function sameFileContextFixture(): GenerationContextV1 {
+  const baseSha = "4".repeat(40);
+  const headSha = "5".repeat(40);
+  const patch = Array.from({ length: 5 }, (_, index) => {
+    const line = index * 20 + 1;
+    return [
+      `@@ -${String(line)},1 +${String(line)},1 @@`,
+      `-return oldBehavior${String(index)};`,
+      `+return newBehavior${String(index)};`,
+    ].join("\n");
+  }).join("\n");
+  const bounded = buildBoundedRevisionSourceV1({
+    githubPullRequestId: "9002",
+    number: 43,
+    state: "open",
+    draft: false,
+    title: "Several bounded changes in one file",
+    body: "Five hunks exercise the deterministic fallback.",
+    authorId: "78",
+    authorLogin: "contributor",
+    headSha,
+    baseSha,
+    changedFiles: 1,
+    isFork: false,
+    files: [
+      {
+        ...changedFile("src/feature.ts", patch),
+        additions: 5,
+        deletions: 5,
+        changes: 10,
+      },
+    ],
+    limitsHit: {
+      files: false,
+      patchBytes: false,
+      patchUnavailable: false,
+    },
+  });
+  const analysis = analyzePullRequestPatch(boundedRevisionSourcePatch(bounded));
+  return buildGenerationContextV1({
+    revisionId: "10000000-0000-4000-8000-000000000011",
+    analysisSnapshotId: "10000000-0000-4000-8000-000000000012",
     boundedSource: bounded,
     analysis,
     excerpts: [],

--- a/packages/questions/src/planner.test.ts
+++ b/packages/questions/src/planner.test.ts
@@ -11,6 +11,7 @@ import {
   ProofPlanSchema,
   createPracticeSet,
   planProof,
+  planProofBudget,
   practiceAndProofAreSeparated,
   type PlannerClock,
 } from "./index";
@@ -95,6 +96,73 @@ describe("versioned proof planner", () => {
     expect(
       new Set(plan.questions.map((question) => question.prompt)).size,
     ).toBe(plan.questions.length);
+  });
+
+  it("keeps same-file multi-hunk prompts unique across head-bound orderings", () => {
+    const sameFilePatch = patch([
+      {
+        path: "src/auth/session.ts",
+        kind: "text" as const,
+        additions: 4,
+        deletions: 4,
+        patch: [
+          "@@ -1,1 +1,1 @@",
+          "-return session;",
+          "+return authenticate(session);",
+          "@@ -20,1 +20,1 @@",
+          "-return role;",
+          "+return authorize(role);",
+          "@@ -40,1 +40,1 @@",
+          "-return request;",
+          "+return transaction(() => request);",
+          "@@ -60,1 +60,1 @@",
+          "-return token;",
+          "+return lock(token);",
+        ].join("\n"),
+      },
+    ]);
+
+    for (let index = 1; index <= 64; index += 1) {
+      const plan = planFor({
+        ...sameFilePatch,
+        headSha: index.toString(16).padStart(40, "0"),
+      });
+      expect(plan.questionBudget).toBeGreaterThanOrEqual(4);
+      expect(
+        new Set(plan.questions.map((question) => question.prompt)).size,
+      ).toBe(plan.questionBudget);
+      expect(
+        plan.questions.every((question) =>
+          question.prompt.includes(
+            `anchor ${question.anchor.id} in src/auth/session.ts near new line ${String(question.anchor.newStart)}`,
+          ),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("plans only the analyzer-owned budget without rendering V1 questions", () => {
+    const analysis = analyzePullRequestPatch(
+      patch([
+        textFile("apps/web/route.ts", [
+          "-return oldResponse;",
+          "+return new Response('created', { status: 201 });",
+        ]),
+        textFile("packages/orders/service.ts", [
+          "-return insert(command);",
+          "+return insert(normalize(command));",
+        ]),
+      ]),
+    );
+    expect(
+      planProofBudget({
+        analysis,
+        policy: DEFAULT_REPOSITORY_POLICY_V1,
+      }),
+    ).toMatchObject({
+      status: "ready",
+      questionBudget: 2,
+    });
   });
 
   it("creates four or five questions for auth, migration and concurrency risk", () => {

--- a/packages/questions/src/planner.ts
+++ b/packages/questions/src/planner.ts
@@ -2,10 +2,11 @@ import { createHash } from "node:crypto";
 import type { AnalysisSnapshot, DiffAnchor } from "@slopproof/analysis";
 import {
   PlanProofInputSchema,
+  PlanProofBudgetInputSchema,
   PracticeInputSchema,
   PracticeSetSchema,
   ProofPlanSchema,
-  type PlanProofInput,
+  type PlanProofBudgetInput,
   type PracticeSet,
   type ProofPlan,
   type ProofQuestion,
@@ -63,7 +64,20 @@ function stableOrder<T>(
   );
 }
 
-function requestedBudget(input: PlanProofInput): number {
+export type ProofBudgetPlan =
+  | {
+      status: "ready";
+      questionBudget: number;
+      rationale: string[];
+    }
+  | {
+      status: "split_recommended";
+      questionBudget: 0;
+      rationale: string[];
+      splitRecommendation: string;
+    };
+
+function requestedBudget(input: PlanProofBudgetInput): number {
   const { analysis, policy } = input;
   if (analysis.riskLevel === "mega" || analysis.anchors.length === 0) {
     return 0;
@@ -129,7 +143,7 @@ function candidatePool(analysis: AnalysisSnapshot): Candidate[] {
 }
 
 function promptFor(candidate: Candidate): string {
-  const location = `the supplied ${candidate.focus} anchor in ${candidate.anchor.file}`;
+  const location = `the supplied ${candidate.focus} anchor ${candidate.anchor.id} in ${boundedDisplayPath(candidate.anchor.file)} near new line ${String(candidate.anchor.newStart)}`;
   switch (candidate.intent) {
     case "explain":
       return `Explain the observable before-and-after behavior at ${location}, and why the new behavior is intended.`;
@@ -190,9 +204,9 @@ function rubricFor(candidate: Candidate): ProofQuestion["rubric"] {
   }
 }
 
-function rationale(input: PlanProofInput, budget: number): string[] {
+function rationale(input: PlanProofBudgetInput, budget: number): string[] {
   const output = [
-    `Risk class ${input.analysis.riskLevel} maps to ${String(budget)} proof question${budget === 1 ? "" : "s"} under planner v1.`,
+    `Risk class ${input.analysis.riskLevel} maps to ${String(budget)} proof question${budget === 1 ? "" : "s"} under the repository proof policy.`,
     `Risk vector: scope=${String(input.analysis.riskVector.scope)}, sensitive=${String(input.analysis.riskVector.sensitiveSurface)}, migration=${String(input.analysis.riskVector.migration)}, concurrency=${String(input.analysis.riskVector.concurrency)}.`,
   ];
   if (input.analysis.generatedChangedLines > 0) {
@@ -203,16 +217,44 @@ function rationale(input: PlanProofInput, budget: number): string[] {
   return output;
 }
 
+export function planProofBudget(rawInput: unknown): ProofBudgetPlan {
+  const input = PlanProofBudgetInputSchema.parse(rawInput);
+  const questionBudget = requestedBudget(input);
+  const reasons = rationale(input, questionBudget);
+  if (input.analysis.riskLevel === "mega") {
+    return {
+      status: "split_recommended",
+      questionBudget: 0,
+      rationale: reasons,
+      splitRecommendation:
+        "Split or narrow the pull request so each proof can be grounded in a bounded, reviewable behavior set.",
+    };
+  }
+  if (input.analysis.anchors.length === 0) {
+    return {
+      status: "split_recommended",
+      questionBudget: 0,
+      rationale: reasons,
+      splitRecommendation:
+        "Provide a text patch with visible hunk anchors before creating proof questions.",
+    };
+  }
+  return { status: "ready", questionBudget, rationale: reasons };
+}
+
 export function planProof(
   rawInput: unknown,
   dependencies: PlannerDependencies,
 ): ProofPlan {
   const input = PlanProofInputSchema.parse(rawInput);
-  const budget = requestedBudget(input);
+  const budgetPlan = planProofBudget({
+    analysis: input.analysis,
+    policy: input.policy,
+  });
+  const budget = budgetPlan.questionBudget;
   const domainSeed = `proof:${input.serverSeed}:${input.analysis.headSha}:${input.versions.planner}:${input.versions.questionTemplates}`;
   const seedCommitment = sha256(domainSeed);
-  const splitRecommended =
-    input.analysis.riskLevel === "mega" || input.analysis.anchors.length === 0;
+  const splitRecommended = budgetPlan.status === "split_recommended";
   const candidates = stableOrder(
     candidatePool(input.analysis),
     domainSeed,
@@ -249,13 +291,10 @@ export function planProof(
       ? ("split_recommended" as const)
       : ("ready" as const),
     questionBudget: questions.length,
-    rationale: rationale(input, questions.length),
+    rationale: budgetPlan.rationale,
     ...(splitRecommended
       ? {
-          splitRecommendation:
-            input.analysis.riskLevel === "mega"
-              ? "Split or narrow the pull request so each proof can be grounded in a bounded, reviewable behavior set."
-              : "Provide a text patch with visible hunk anchors before creating proof questions.",
+          splitRecommendation: budgetPlan.splitRecommendation,
         }
       : {}),
     seedCommitment,
@@ -269,6 +308,11 @@ export function planProof(
     }),
   );
   return ProofPlanSchema.parse({ ...planWithoutHash, planHash });
+}
+
+function boundedDisplayPath(path: string): string {
+  if (path.length <= 240) return path;
+  return `${path.slice(0, 118)}…${path.slice(-118)}`;
 }
 
 const PRACTICE_POOL = [

--- a/packages/questions/src/schema.ts
+++ b/packages/questions/src/schema.ts
@@ -29,6 +29,13 @@ export const PlanProofInputSchema = z
 
 export type PlanProofInput = z.infer<typeof PlanProofInputSchema>;
 
+export const PlanProofBudgetInputSchema = PlanProofInputSchema.pick({
+  analysis: true,
+  policy: true,
+}).strict();
+
+export type PlanProofBudgetInput = z.infer<typeof PlanProofBudgetInputSchema>;
+
 export const QuestionIntentSchema = z.enum([
   "explain",
   "predict",

--- a/tests/integration/product-flow.integration.test.ts
+++ b/tests/integration/product-flow.integration.test.ts
@@ -27,7 +27,7 @@ import { expireAttempt } from "../../apps/worker/src/attempt-expiry";
 import {
   createWorkerCheckIntentWriter,
   LocalFakeRevisionPatchSource,
-  prepareRevision,
+  prepareRevisionFailClosed,
   type CheckIntentWriter as WorkerCheckIntentWriter,
 } from "../../apps/worker/src/revision-preparation";
 import { persistGenerationContextV1InTransaction } from "../../apps/worker/src/generation-context-repository";
@@ -68,6 +68,7 @@ databaseDescribe("complete current-SHA product flow", () => {
   let checkIntents: RecordingCheckIntentWriter;
   let workerCheckIntents: WorkerCheckIntentWriter;
   let storage: FakeAbortStorage;
+  let failGenerationContextPersistence = false;
 
   beforeAll(async () => {
     connection = connectDatabase(databaseUrl!);
@@ -88,13 +89,18 @@ databaseDescribe("complete current-SHA product flow", () => {
       jobQueue,
       "analysis.prepare-revision",
       async (job) => {
-        await prepareRevision(job.data, {
+        await prepareRevisionFailClosed(job.data, {
           pool: connection.pool,
           queue: jobQueue,
           checkIntents: workerCheckIntents,
           patchSource: new LocalFakeRevisionPatchSource(),
           generationContexts: {
-            persist: persistGenerationContextV1InTransaction,
+            persist: async (client, context) => {
+              if (failGenerationContextPersistence) {
+                throw new Error("private simulated planner invariant");
+              }
+              return persistGenerationContextV1InTransaction(client, context);
+            },
           },
         });
       },
@@ -136,6 +142,7 @@ databaseDescribe("complete current-SHA product flow", () => {
   beforeEach(async () => {
     storage.calls.length = 0;
     checkIntents.calls.length = 0;
+    failGenerationContextPersistence = false;
     await connection.pool.query(`
       TRUNCATE TABLE
         audit_events, deletion_jobs, check_runs, review_decisions, evaluations,
@@ -246,6 +253,32 @@ databaseDescribe("complete current-SHA product flow", () => {
       firstAttempt.id,
       "attempt.expiry_stale_cleanup",
     );
+  });
+
+  it("completes a deterministic preparation failure once without a 404-shaped state", async () => {
+    failGenerationContextPersistence = true;
+    const request = webhook({
+      deliveryId: "71000000-0000-4000-8000-000000000003",
+      action: "opened",
+      headSha: "8".repeat(40),
+    });
+    await ingestPullRequestWebhook({
+      pool: connection.pool,
+      queue: githubQueue,
+      secret: webhookSecret,
+      ...request,
+    });
+
+    const failed = await waitForPreparationFailure(connection, "8".repeat(40));
+    expect(failed).toMatchObject({
+      status: "completed",
+      conclusion: "action_required",
+      intent_reason: "preparation_failed",
+      attempt_count: 0,
+      failure_audit_count: 1,
+    });
+    expect(failed.public_summary).toContain("Maintainer action is required");
+    expect(failed.public_summary).not.toContain("simulated");
   });
 
   it("aborts ciphertext upload once, appends technical retry and creates one replacement", async () => {
@@ -646,6 +679,49 @@ async function waitForReadyAttempt(
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
   throw new Error(`ready attempt for ${headSha} was not created`);
+}
+
+async function waitForPreparationFailure(
+  connection: DatabaseConnection,
+  headSha: string,
+): Promise<{
+  status: string;
+  conclusion: string | null;
+  intent_reason: string | null;
+  public_summary: string;
+  attempt_count: number;
+  failure_audit_count: number;
+}> {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    const result = await connection.pool.query<{
+      status: string;
+      conclusion: string | null;
+      intent_reason: string | null;
+      public_summary: string;
+      attempt_count: number;
+      failure_audit_count: number;
+    }>(
+      `SELECT check_run.status, check_run.conclusion,
+              check_run.intent_reason, check_run.public_summary,
+              (SELECT count(*)::int FROM attempts attempt
+                WHERE attempt.revision_id = revision.id) AS attempt_count,
+              (SELECT count(*)::int FROM audit_events audit
+                WHERE audit.object_type = 'revision'
+                  AND audit.object_id = revision.id::text
+                  AND audit.action = 'analysis.preparation_failed')
+                AS failure_audit_count
+         FROM pull_request_revisions revision
+         JOIN check_runs check_run ON check_run.revision_id = revision.id
+        WHERE revision.head_sha = $1`,
+      [headSha],
+    );
+    if (result.rows[0]?.intent_reason === "preparation_failed") {
+      return result.rows[0];
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`preparation failure for ${headSha} was not persisted`);
 }
 
 function authorSession(attempt: {

--- a/tests/integration/semantic-generation-persistence.integration.test.ts
+++ b/tests/integration/semantic-generation-persistence.integration.test.ts
@@ -80,7 +80,10 @@ databaseDescribe("Gate 4 semantic persistence and served Proof V2", () => {
     generationContextId = seeded.generationContextId;
     generationContext = seeded.context;
     scheduler = schedulerFixture();
-    proofReady = { write: vi.fn(async () => undefined) };
+    proofReady = {
+      write: vi.fn(async () => undefined),
+      fail: vi.fn(async () => undefined),
+    };
     repository = new PostgresSemanticGenerationRepository(
       database,
       new PayloadCipher(Buffer.alloc(32, 7)),
@@ -864,6 +867,7 @@ databaseDescribe("Gate 4 semantic persistence and served Proof V2", () => {
     const recoveryScheduler = schedulerFixture();
     const recoveryProofReady: SemanticProofReadyWriter = {
       write: vi.fn(async () => undefined),
+      fail: vi.fn(async () => undefined),
     };
     const recoveredRepository = new PostgresSemanticGenerationRepository(
       database,


### PR DESCRIPTION
## Failure

A valid multi-hunk diff could select two V1 planner candidates with the same intent, focus, and file. Their rendered prompts were byte-identical because the prompt omitted the anchor identity. Production rendered this legacy V1 plan before scheduling the stricter V2 pipeline, so schema validation failed deterministically, pg-boss retried the same permanent error, no semantic budget or attempt was created, and the contributor route rendered a misleading 404.

## Change

- split deterministic risk/split/budget planning from legacy V1 question rendering
- route production directly from the frozen analysis/context into the existing V2 proof generator
- retain mandatory one-anchor/one-patch-reference binding plus schema, content, uniqueness, and exact-budget validation
- retain exactly one semantic repair attempt; transport/provider failure uses the deterministic position-bound fallback
- make the V1 compatibility prompts anchor- and line-specific as defense in depth
- classify transient database/network/HTTP failures as retryable and persist other preparation failures once as completed/action_required with reason preparation_failed
- prevent recovery sweeps from re-enqueuing terminally failed revisions
- show explicit Preparing or system-failure contributor states instead of 404, and hide the contributor CTA until preparation has a budget
- add migration 0018 for the new check-intent reason

## Regression coverage

- 64 deterministic head-bound orderings over multiple same-file anchors
- five-question same-file V2 fallback with exact anchor/reference bindings
- single semantic-repair and provider-fallback contracts remain covered
- deterministic versus transient job-boundary errors
- PostgreSQL product flow persists one safe preparation_failed result and no attempt
- contributor preparing/failed/ready state and CTA readiness

## Verification

- pnpm verify
- PostgreSQL integration suite against the CI-pinned PostgreSQL 18.4 image: 15 files, 110 tests
- unit suite: 103 files, 869 tests

## Deployment note

This PR adds a database enum migration. Merge does not deploy; production promotion must use the migration-aware release path and its existing backup/restore boundary.
