### PR TITLE
fix: stream multimodal judge within reserved deadlines

### DIFF
--- a/apps/worker/src/multimodal-provider-factory.ts
+++ b/apps/worker/src/multimodal-provider-factory.ts
@@ -63,6 +63,9 @@ export function createMultimodalJudgeProvider(
       },
       dependencies.hetzner,
     ),
+    {
+      now: () => (dependencies.clock?.now() ?? new Date()).getTime(),
+    },
   );
 }
 

--- a/packages/providers/src/errors.test.ts
+++ b/packages/providers/src/errors.test.ts
@@ -28,6 +28,25 @@ describe("provider HTTP status helpers", () => {
 });
 
 describe("isTransportFailure", () => {
+  it("hops after an exhausted provider stream idle timeout", () => {
+    expect(
+      isTransportFailure(
+        new ProviderError(
+          "PROVIDER_TIMEOUT",
+          "retryable",
+          "Multimodal provider exhausted its stream idle timeout budget",
+          {
+            telemetry: {
+              lastFailureKind: "timeout",
+              httpStatusClass: null,
+              transportAttemptCount: 1,
+            },
+          },
+        ),
+      ),
+    ).toBe(true);
+  });
+
   it("hops after exhausted transient 402/404/408 retries", () => {
     for (const httpStatus of [402, 404, 408]) {
       expect(

--- a/packages/providers/src/errors.ts
+++ b/packages/providers/src/errors.ts
@@ -5,6 +5,7 @@ export const PROVIDER_ERROR_CODES = [
   "RUBRIC_MISMATCH",
   "PATCH_ANCHOR_MISMATCH",
   "DEADLINE_EXCEEDED",
+  "PROVIDER_TIMEOUT",
   "PROVIDER_UNAVAILABLE",
   "INVALID_CIPHER_KEY",
   "INVALID_CIPHER_PAYLOAD",
@@ -168,6 +169,8 @@ export function isTransportFailure(error: unknown): boolean {
   const kind = error.telemetry?.lastFailureKind;
   if (kind !== undefined && !TRANSPORT_FAILURE_KINDS.has(kind)) return false;
   return (
-    error.code === "DEADLINE_EXCEEDED" || error.code === "PROVIDER_UNAVAILABLE"
+    error.code === "DEADLINE_EXCEEDED" ||
+    error.code === "PROVIDER_TIMEOUT" ||
+    error.code === "PROVIDER_UNAVAILABLE"
   );
 }

--- a/packages/providers/src/hetzner-multimodal.test.ts
+++ b/packages/providers/src/hetzner-multimodal.test.ts
@@ -31,6 +31,9 @@ describe("HetznerMultimodalJudgeProvider", () => {
           redirect: "error",
           referrerPolicy: "no-referrer",
         });
+        expect(new Headers(init?.headers).get("accept")).toBe(
+          "text/event-stream",
+        );
         return completionResponse(validCandidate());
       },
     );
@@ -44,11 +47,14 @@ describe("HetznerMultimodalJudgeProvider", () => {
       outcome: "generated",
       degraded: false,
     });
+    expect(JSON.stringify(result)).not.toContain(
+      "private reasoning must never be persisted",
+    );
     expect(fetchImpl).toHaveBeenCalledTimes(1);
     expect(bodies[0]).toMatchObject({
       model: "vision-model",
       store: false,
-      stream: false,
+      stream: true,
       chat_template_kwargs: { thinking: false },
     });
     expect(bodies[0]).not.toHaveProperty("tools");
@@ -121,6 +127,42 @@ describe("HetznerMultimodalJudgeProvider", () => {
     expect(JSON.stringify(body)).not.toContain("data:image");
   });
 
+  it("assembles fragmented SSE content before validating the candidate", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(fragmentedCompletionResponse(validCandidate()));
+
+    const result = await providerWith(fetchImpl).evaluate(
+      { ...inputFixture(), frames: [] },
+      contextFixture(),
+    );
+
+    expect(result.candidate.recommendation).toBe("pass");
+    expect(result.metadata.tokenUsage).toEqual({
+      inputTokens: 25,
+      outputTokens: 10,
+    });
+  });
+
+  it("accepts the single fenced JSON object emitted by the live Ox stream", async () => {
+    const fenced = [
+      "```json",
+      JSON.stringify({ result: validCandidate() }),
+      "```",
+    ].join("\n");
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(completionTextResponse(fenced));
+
+    const result = await providerWith(fetchImpl).evaluate(
+      { ...inputFixture(), frames: [] },
+      contextFixture(),
+    );
+
+    expect(result.candidate.recommendation).toBe("pass");
+    expect(result.metadata.outcome).toBe("generated");
+  });
+
   it.each([400, 415, 422])(
     "after Hetzner hop-vision HTTP %s, evaluates from the transcript without frames",
     async (status) => {
@@ -172,7 +214,7 @@ describe("HetznerMultimodalJudgeProvider", () => {
           fetchImpl,
           policy: {
             maxAttempts: 3,
-            attemptTimeoutMs: 100,
+            streamIdleTimeoutMs: 100,
             now: () => NOW.getTime(),
             random: () => 0,
             sleep: async () => undefined,
@@ -687,7 +729,7 @@ describe("HetznerMultimodalJudgeProvider", () => {
           fetchImpl,
           policy: {
             maxAttempts: 3,
-            attemptTimeoutMs: 100,
+            streamIdleTimeoutMs: 100,
             now: () => NOW.getTime(),
             random: () => 0,
             sleep: async () => undefined,
@@ -729,7 +771,7 @@ describe("HetznerMultimodalJudgeProvider", () => {
             fetchImpl: primaryFetch,
             policy: {
               maxAttempts: 3,
-              attemptTimeoutMs: 100,
+              streamIdleTimeoutMs: 100,
               now: () => NOW.getTime(),
               random: () => 0,
               sleep: async () => undefined,
@@ -748,7 +790,7 @@ describe("HetznerMultimodalJudgeProvider", () => {
             fetchImpl: fallbackFetch,
             policy: {
               maxAttempts: 3,
-              attemptTimeoutMs: 100,
+              streamIdleTimeoutMs: 100,
               now: () => NOW.getTime(),
               random: () => 0,
               sleep: async () => undefined,
@@ -794,7 +836,7 @@ describe("HetznerMultimodalJudgeProvider", () => {
           fetchImpl: primaryFetch,
           policy: {
             maxAttempts: 3,
-            attemptTimeoutMs: 100,
+            streamIdleTimeoutMs: 100,
             now: () => NOW.getTime(),
             random: () => 0,
             sleep: async () => undefined,
@@ -813,7 +855,7 @@ describe("HetznerMultimodalJudgeProvider", () => {
           fetchImpl: fallbackFetch,
           policy: {
             maxAttempts: 3,
-            attemptTimeoutMs: 100,
+            streamIdleTimeoutMs: 100,
             now: () => NOW.getTime(),
             random: () => 0,
             sleep: async () => undefined,
@@ -864,7 +906,7 @@ describe("HetznerMultimodalJudgeProvider", () => {
           fetchImpl: primaryFetch,
           policy: {
             maxAttempts: 3,
-            attemptTimeoutMs: 100,
+            streamIdleTimeoutMs: 100,
             now: () => NOW.getTime(),
             random: () => 0,
             sleep: async () => undefined,
@@ -883,7 +925,7 @@ describe("HetznerMultimodalJudgeProvider", () => {
           fetchImpl: fallbackFetch,
           policy: {
             maxAttempts: 3,
-            attemptTimeoutMs: 100,
+            streamIdleTimeoutMs: 100,
             now: () => NOW.getTime(),
             random: () => 0,
             sleep: async () => undefined,
@@ -932,7 +974,7 @@ describe("HetznerMultimodalJudgeProvider", () => {
           fetchImpl: primaryFetch,
           policy: {
             maxAttempts: 3,
-            attemptTimeoutMs: 100,
+            streamIdleTimeoutMs: 100,
             now: () => NOW.getTime(),
             random: () => 0,
             sleep: async () => undefined,
@@ -951,7 +993,7 @@ describe("HetznerMultimodalJudgeProvider", () => {
           fetchImpl: fallbackFetch,
           policy: {
             maxAttempts: 3,
-            attemptTimeoutMs: 100,
+            streamIdleTimeoutMs: 100,
             now: () => NOW.getTime(),
             random: () => 0,
             sleep: async () => undefined,
@@ -974,7 +1016,7 @@ describe("HetznerMultimodalJudgeProvider", () => {
     expect(fallbackFetch).toHaveBeenCalledTimes(2);
   });
 
-  it("hard-times out a fetch that ignores AbortSignal", async () => {
+  it("reports an exhausted stream idle budget separately from the shared deadline", async () => {
     const fetchImpl = vi.fn<typeof fetch>(
       async () => new Promise<Response>(() => undefined),
     );
@@ -985,10 +1027,40 @@ describe("HetznerMultimodalJudgeProvider", () => {
     await expect(
       providerWith(fetchImpl, {
         maxAttempts: 1,
-        attemptTimeoutMs: 5,
+        streamIdleTimeoutMs: 5,
         now: Date.now,
       }).evaluate(inputFixture(), liveContext),
-    ).rejects.toMatchObject({ code: "DEADLINE_EXCEEDED" });
+    ).rejects.toMatchObject({
+      code: "PROVIDER_TIMEOUT",
+      telemetry: {
+        lastFailureKind: "timeout",
+        transportAttemptCount: 1,
+      },
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps DEADLINE_EXCEEDED for the actual provider-hop deadline", async () => {
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () => new Promise<Response>(() => undefined),
+    );
+    const liveContext = {
+      ...contextFixture(),
+      deadlineAt: new Date(Date.now() + 20),
+    };
+    await expect(
+      providerWith(fetchImpl, {
+        maxAttempts: 1,
+        streamIdleTimeoutMs: 100,
+        now: Date.now,
+      }).evaluate(inputFixture(), liveContext),
+    ).rejects.toMatchObject({
+      code: "DEADLINE_EXCEEDED",
+      telemetry: {
+        lastFailureKind: "deadline_exceeded",
+        transportAttemptCount: 1,
+      },
+    });
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
@@ -1036,7 +1108,7 @@ function providerWith(
       fetchImpl,
       policy: {
         maxAttempts: 3,
-        attemptTimeoutMs: 100,
+        streamIdleTimeoutMs: 100,
         now: () => NOW.getTime(),
         random: () => 0,
         sleep: async () => undefined,
@@ -1183,8 +1255,64 @@ function completionResponse(candidate: unknown): Response {
 }
 
 function completionTextResponse(content: string): Response {
-  return Response.json({
-    choices: [{ message: { role: "assistant", content } }],
-    usage: { prompt_tokens: 25, completion_tokens: 10 },
-  });
+  const events = [
+    {
+      choices: [
+        {
+          delta: { reasoning: "private reasoning must never be persisted" },
+          finish_reason: null,
+        },
+      ],
+      usage: null,
+    },
+    {
+      choices: [{ delta: { content }, finish_reason: null }],
+      usage: null,
+    },
+    {
+      choices: [{ delta: {}, finish_reason: "stop" }],
+    },
+    {
+      choices: [{ delta: {}, finish_reason: "stop" }],
+      usage: { prompt_tokens: 25, completion_tokens: 10 },
+    },
+  ];
+  return new Response(
+    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
+    { headers: { "content-type": "text/event-stream; charset=utf-8" } },
+  );
+}
+
+function fragmentedCompletionResponse(candidate: unknown): Response {
+  const content = JSON.stringify({ result: candidate });
+  const midpoint = Math.floor(content.length / 2);
+  const events = [
+    {
+      choices: [
+        { delta: { content: content.slice(0, midpoint) }, finish_reason: null },
+      ],
+    },
+    {
+      choices: [
+        { delta: { content: content.slice(midpoint) }, finish_reason: null },
+      ],
+    },
+    {
+      choices: [{ delta: {}, finish_reason: "stop" }],
+      usage: { prompt_tokens: 25, completion_tokens: 10 },
+    },
+  ];
+  const payload = `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`;
+  const bytes = new TextEncoder().encode(payload);
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (let offset = 0; offset < bytes.length; offset += 7) {
+          controller.enqueue(bytes.slice(offset, offset + 7));
+        }
+        controller.close();
+      },
+    }),
+    { headers: { "content-type": "text/event-stream" } },
+  );
 }

--- a/packages/providers/src/hetzner-multimodal.ts
+++ b/packages/providers/src/hetzner-multimodal.ts
@@ -15,11 +15,15 @@ import { ProviderContextV1Schema, type ProviderContextV1 } from "./contracts";
 import { JudgeEvaluateFailureDiagnosticsV1Schema } from "./judge-diagnostics";
 
 const MAX_TRANSPORT_ATTEMPTS = 3;
-const DEFAULT_ATTEMPT_TIMEOUT_MS = 20_000;
+// Only content deltas, finish_reason, or usage reset this timeout. The absolute
+// provider-hop deadline remains the hard upper bound while tokens are flowing.
+const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 150_000;
 const DEFAULT_MAX_RESPONSE_BYTES = 512 * 1_024;
 const MAX_RESPONSE_BYTES = 1024 * 1_024;
 const MAX_REQUEST_BYTES = 4 * 1_024 * 1_024;
 const MAX_MODEL_TEXT_BYTES = 512 * 1_024;
+const MAX_SSE_EVENT_BYTES = 256 * 1_024;
+const MAX_SSE_EVENT_COUNT = 20_000;
 const MAX_INLINE_FRAME_BYTES = 512 * 1_024;
 const MAX_INLINE_FRAME_TOTAL_BYTES = 2 * 1_024 * 1_024;
 const VISION_CAPABILITY_REJECTED_STATUSES = new Set([400, 404, 415, 422]);
@@ -405,7 +409,7 @@ export type HetznerMultimodalJudgeConfigV1 = z.input<
 
 export type HetznerMultimodalJudgeRequestPolicy = {
   maxAttempts?: number;
-  attemptTimeoutMs?: number;
+  streamIdleTimeoutMs?: number;
   maxResponseBytes?: number;
   now?: () => number;
   random?: () => number;
@@ -419,7 +423,7 @@ export type HetznerMultimodalJudgeDependencies = {
 
 type ResolvedRequestPolicy = {
   maxAttempts: number;
-  attemptTimeoutMs: number;
+  streamIdleTimeoutMs: number;
   maxResponseBytes: number;
   now: () => number;
   random: () => number;
@@ -438,23 +442,38 @@ type TokenUsage = {
   outputTokens: number;
 } | null;
 
-const OpenAiChatCompletionSchema = z
+type StreamRequestResult = {
+  content: string | undefined;
+  finishReason: string | null;
+  usage: TokenUsage;
+  transportAttemptCount: number;
+};
+
+const OpenAiStreamChunkSchema = z
   .object({
     choices: z
       .array(
         z
           .object({
-            message: z
+            delta: z
               .object({
-                content: z.union([z.string(), z.null()]),
+                content: z.string().nullable().optional(),
+                reasoning: z.string().nullable().optional(),
               })
               .passthrough(),
+            finish_reason: z.string().nullable().optional(),
           })
           .passthrough(),
       )
-      .min(1)
       .max(8),
     usage: z.unknown().optional(),
+  })
+  .passthrough();
+
+const OpenAiUsageSchema = z
+  .object({
+    prompt_tokens: z.number().int().nonnegative().max(10_000_000),
+    completion_tokens: z.number().int().nonnegative().max(10_000_000),
   })
   .passthrough();
 
@@ -634,7 +653,7 @@ export class HetznerMultimodalJudgeProvider implements InlineMultimodalJudgeProv
     if (Buffer.byteLength(body, "utf8") > MAX_REQUEST_BYTES) {
       throw invalidInputError();
     }
-    const envelope = await requestJsonWithRetry({
+    const streamed = await requestStreamWithRetry({
       endpoint: this.endpoint,
       apiKey: this.apiKey,
       body,
@@ -643,18 +662,17 @@ export class HetznerMultimodalJudgeProvider implements InlineMultimodalJudgeProv
       policy: this.policy,
       allowVisionCapabilityFallback,
     });
-    const completion = OpenAiChatCompletionSchema.safeParse(envelope);
-    if (!completion.success) throw invalidOutputError();
-    const content = completion.data.choices[0]?.message.content;
     const extracted =
-      typeof content === "string" ? tryExtractJsonObject(content) : undefined;
+      typeof streamed.content === "string"
+        ? tryExtractJsonObject(streamed.content)
+        : undefined;
     const output =
       extracted === undefined
         ? { malformedMultimodalOutput: true }
         : unwrapResultEnvelope(extracted);
     return {
       output,
-      tokenUsage: tokenUsage(completion.data.usage),
+      tokenUsage: streamed.usage,
     };
   }
 }
@@ -998,7 +1016,7 @@ function buildRequestBody(
   return {
     model,
     store: false,
-    stream: false,
+    stream: true,
     temperature: 0,
     max_tokens: 6_000,
     ...(hetzner
@@ -1026,7 +1044,7 @@ function buildRequestBody(
   } as const;
 }
 
-async function requestJsonWithRetry(input: {
+async function requestStreamWithRetry(input: {
   endpoint: string;
   apiKey: string;
   body: string;
@@ -1034,20 +1052,47 @@ async function requestJsonWithRetry(input: {
   fetchImpl: typeof fetch;
   policy: ResolvedRequestPolicy;
   allowVisionCapabilityFallback: boolean;
-}): Promise<unknown> {
+}): Promise<StreamRequestResult> {
   let lastFailure: RetryableFailure | undefined;
   for (let attempt = 1; attempt <= input.policy.maxAttempts; attempt += 1) {
     const remaining = input.deadlineAtMs - input.policy.now();
-    if (remaining <= 0) throw deadlineError();
+    if (remaining <= 0) {
+      throw deadlineError(retryableFailureTelemetry(lastFailure, attempt - 1));
+    }
     const controller = new AbortController();
     let timeout: ReturnType<typeof setTimeout> | undefined;
     let response: Response | undefined;
+    let timeoutKind: "idle" | "deadline" | undefined;
     try {
-      const operation = (async (): Promise<unknown> => {
+      let rejectTimeout: ((reason: typeof timeoutMarker) => void) | undefined;
+      const timeoutPromise = new Promise<never>((_resolve, reject) => {
+        rejectTimeout = reject;
+      });
+      const registerActivity = (): void => {
+        if (timeout !== undefined) clearTimeout(timeout);
+        const currentRemaining = input.deadlineAtMs - input.policy.now();
+        const activityWindow = Math.max(
+          1,
+          Math.min(input.policy.streamIdleTimeoutMs, currentRemaining),
+        );
+        const expiryKind =
+          currentRemaining <= input.policy.streamIdleTimeoutMs
+            ? "deadline"
+            : "idle";
+        timeout = setTimeout(() => {
+          timeoutKind = expiryKind;
+          controller.abort();
+          rejectTimeout?.(timeoutMarker);
+        }, activityWindow);
+      };
+      registerActivity();
+      const operation = (async (): Promise<
+        Omit<StreamRequestResult, "transportAttemptCount">
+      > => {
         response = await input.fetchImpl(input.endpoint, {
           method: "POST",
           headers: {
-            accept: "application/json",
+            accept: "text/event-stream",
             authorization: `Bearer ${input.apiKey}`,
             "content-type": "application/json",
           },
@@ -1059,29 +1104,26 @@ async function requestJsonWithRetry(input: {
           referrerPolicy: "no-referrer",
         });
         if (!response.ok) throw responseStatusMarker(response.status);
-        const text = await readBoundedResponseText(
+        registerActivity();
+        return readBoundedSseResponse(
           response,
           input.policy.maxResponseBytes,
+          registerActivity,
         );
-        try {
-          return JSON.parse(text.replace(/^\uFEFF/u, ""));
-        } catch {
-          throw new SafeProtocolError("malformed_response");
-        }
       })();
-      return await Promise.race([
-        operation,
-        new Promise<never>((_resolve, reject) => {
-          timeout = setTimeout(
-            () => {
-              controller.abort();
-              reject(timeoutMarker);
-            },
-            Math.max(1, Math.min(input.policy.attemptTimeoutMs, remaining)),
-          );
-        }),
-      ]);
+      const payload = await Promise.race([operation, timeoutPromise]);
+      return { ...payload, transportAttemptCount: attempt };
     } catch (error) {
+      if (
+        timeoutKind === "deadline" &&
+        (error === timeoutMarker || controller.signal.aborted)
+      ) {
+        throw deadlineError({
+          lastFailureKind: "deadline_exceeded",
+          httpStatusClass: null,
+          transportAttemptCount: attempt,
+        });
+      }
       if (error instanceof SafeProtocolError) {
         if (error.kind === "response_stream") {
           lastFailure = { kind: "network" };
@@ -1137,7 +1179,8 @@ async function requestJsonWithRetry(input: {
         }
       } else {
         lastFailure =
-          error === timeoutMarker || controller.signal.aborted
+          error === timeoutMarker ||
+          (controller.signal.aborted && timeoutKind === "idle")
             ? { kind: "timeout" }
             : { kind: "network" };
       }
@@ -1152,17 +1195,26 @@ async function requestJsonWithRetry(input: {
       lastFailure?.retryAfterMs ?? 0,
     );
     if (input.deadlineAtMs - input.policy.now() <= delay) {
-      throw deadlineError();
+      throw deadlineError(retryableFailureTelemetry(lastFailure, attempt));
     }
     await input.policy.sleep(delay);
   }
   throw retryableProviderError(lastFailure, input.policy.maxAttempts);
 }
 
-async function readBoundedResponseText(
+async function readBoundedSseResponse(
   response: Response,
   maximumBytes: number,
-): Promise<string> {
+  registerGenerationProgress: () => void,
+): Promise<Omit<StreamRequestResult, "transportAttemptCount">> {
+  const contentType = response.headers
+    .get("content-type")
+    ?.split(";", 1)[0]
+    ?.trim()
+    .toLowerCase();
+  if (contentType !== "text/event-stream") {
+    throw new SafeProtocolError("malformed_response");
+  }
   const declaredLength = Number(response.headers.get("content-length"));
   if (Number.isFinite(declaredLength) && declaredLength > maximumBytes) {
     try {
@@ -1176,7 +1228,108 @@ async function readBoundedResponseText(
   const reader = response.body.getReader();
   const decoder = new TextDecoder("utf-8", { fatal: true });
   let bytesRead = 0;
-  let text = "";
+  let pending = "";
+  let eventData: string[] = [];
+  let eventBytes = 0;
+  let eventCount = 0;
+  let doneSeen = false;
+  let content = "";
+  let contentBytes = 0;
+  let finishReason: string | null = null;
+  let usage: TokenUsage = null;
+
+  const commitEvent = (): void => {
+    if (eventData.length === 0) return;
+    const data = eventData.join("\n");
+    eventData = [];
+    eventBytes = 0;
+    if (data === "[DONE]") {
+      doneSeen = true;
+      return;
+    }
+    if (doneSeen || (eventCount += 1) > MAX_SSE_EVENT_COUNT) {
+      throw new SafeProtocolError("malformed_response");
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(data.replace(/^\uFEFF/u, "")) as unknown;
+    } catch {
+      throw new SafeProtocolError("malformed_response");
+    }
+    const chunk = OpenAiStreamChunkSchema.safeParse(parsed);
+    if (!chunk.success) throw new SafeProtocolError("malformed_response");
+    const choice = chunk.data.choices[0];
+    let progressed = false;
+    if (choice?.delta.content !== undefined && choice.delta.content !== null) {
+      const deltaBytes = Buffer.byteLength(choice.delta.content, "utf8");
+      if (contentBytes + deltaBytes > MAX_MODEL_TEXT_BYTES) {
+        throw new SafeProtocolError("response_too_large");
+      }
+      content += choice.delta.content;
+      contentBytes += deltaBytes;
+      if (choice.delta.content.length > 0) progressed = true;
+    }
+    if (
+      choice?.delta.reasoning !== undefined &&
+      choice.delta.reasoning !== null &&
+      choice.delta.reasoning.length > 0
+    ) {
+      progressed = true;
+    }
+    if (choice?.finish_reason !== undefined && choice.finish_reason !== null) {
+      if (finishReason !== null && finishReason !== choice.finish_reason) {
+        throw new SafeProtocolError("malformed_response");
+      }
+      finishReason = choice.finish_reason;
+      progressed = true;
+    }
+    if (chunk.data.usage !== undefined && chunk.data.usage !== null) {
+      const parsedUsage = OpenAiUsageSchema.safeParse(chunk.data.usage);
+      if (!parsedUsage.success) {
+        throw new SafeProtocolError("malformed_response");
+      }
+      usage = {
+        inputTokens: parsedUsage.data.prompt_tokens,
+        outputTokens: parsedUsage.data.completion_tokens,
+      };
+      progressed = true;
+    }
+    if (progressed) registerGenerationProgress();
+  };
+
+  const acceptLine = (rawLine: string): void => {
+    const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+    if (line.length === 0) {
+      commitEvent();
+      return;
+    }
+    if (line.startsWith(":")) return;
+    const separator = line.indexOf(":");
+    const field = separator === -1 ? line : line.slice(0, separator);
+    if (field !== "data") return;
+    let value = separator === -1 ? "" : line.slice(separator + 1);
+    if (value.startsWith(" ")) value = value.slice(1);
+    const valueBytes = Buffer.byteLength(value, "utf8");
+    if (eventBytes + valueBytes > MAX_SSE_EVENT_BYTES) {
+      throw new SafeProtocolError("response_too_large");
+    }
+    eventData.push(value);
+    eventBytes += valueBytes;
+  };
+
+  const acceptText = (value: string): void => {
+    pending += value;
+    let newline = pending.indexOf("\n");
+    while (newline !== -1) {
+      acceptLine(pending.slice(0, newline));
+      pending = pending.slice(newline + 1);
+      newline = pending.indexOf("\n");
+    }
+    if (Buffer.byteLength(pending, "utf8") > MAX_SSE_EVENT_BYTES) {
+      throw new SafeProtocolError("response_too_large");
+    }
+  };
+
   try {
     while (true) {
       const { done, value } = await reader.read();
@@ -1186,10 +1339,22 @@ async function readBoundedResponseText(
         await reader.cancel();
         throw new SafeProtocolError("response_too_large");
       }
-      text += decoder.decode(value, { stream: true });
+      acceptText(decoder.decode(value, { stream: true }));
     }
-    text += decoder.decode();
-    return text;
+    acceptText(decoder.decode());
+    if (pending.length > 0) {
+      acceptLine(pending);
+      pending = "";
+    }
+    commitEvent();
+    if (!doneSeen || finishReason === null) {
+      throw new SafeProtocolError("malformed_response");
+    }
+    return {
+      content: content.length === 0 ? undefined : content,
+      finishReason,
+      usage,
+    };
   } catch (error) {
     if (error instanceof SafeProtocolError) throw error;
     throw new SafeProtocolError("response_stream");
@@ -1264,22 +1429,6 @@ function unwrapResultEnvelope(value: unknown): unknown {
   return keys.length === 1 && keys[0] === "result" ? value.result : value;
 }
 
-function tokenUsage(rawUsage: unknown): TokenUsage {
-  const usage = z
-    .object({
-      prompt_tokens: z.number().int().nonnegative().max(10_000_000),
-      completion_tokens: z.number().int().nonnegative().max(10_000_000),
-    })
-    .passthrough()
-    .safeParse(rawUsage);
-  return usage.success
-    ? {
-        inputTokens: usage.data.prompt_tokens,
-        outputTokens: usage.data.completion_tokens,
-      }
-    : null;
-}
-
 function addTokenUsage(left: TokenUsage, right: TokenUsage): TokenUsage {
   if (right === null) return left;
   if (left === null) return right;
@@ -1341,12 +1490,12 @@ function resolvePolicy(
         .min(1)
         .max(MAX_TRANSPORT_ATTEMPTS)
         .default(MAX_TRANSPORT_ATTEMPTS),
-      attemptTimeoutMs: z
+      streamIdleTimeoutMs: z
         .number()
         .int()
         .positive()
-        .max(120_000)
-        .default(DEFAULT_ATTEMPT_TIMEOUT_MS),
+        .max(180_000)
+        .default(DEFAULT_STREAM_IDLE_TIMEOUT_MS),
       maxResponseBytes: z
         .number()
         .int()
@@ -1357,7 +1506,7 @@ function resolvePolicy(
     .strict()
     .safeParse({
       maxAttempts: rawPolicy.maxAttempts,
-      attemptTimeoutMs: rawPolicy.attemptTimeoutMs,
+      streamIdleTimeoutMs: rawPolicy.streamIdleTimeoutMs,
       maxResponseBytes: rawPolicy.maxResponseBytes,
     });
   if (!parsed.success) throw invalidInputError();
@@ -1525,7 +1674,14 @@ function retryableProviderError(
   transportAttemptCount: number,
 ): ProviderError {
   return failure?.kind === "timeout"
-    ? deadlineError(retryableFailureTelemetry(failure, transportAttemptCount))
+    ? new ProviderError(
+        "PROVIDER_TIMEOUT",
+        "retryable",
+        "Multimodal provider exhausted its stream idle timeout budget",
+        {
+          telemetry: retryableFailureTelemetry(failure, transportAttemptCount),
+        },
+      )
     : new ProviderError(
         "PROVIDER_UNAVAILABLE",
         "retryable",

--- a/packages/providers/src/transport-fallback.test.ts
+++ b/packages/providers/src/transport-fallback.test.ts
@@ -13,6 +13,7 @@ import type {
   SemanticProviderRepairInstructionV1,
 } from "./learning-proof";
 import {
+  MULTIMODAL_TRANSPORT_FALLBACK_RESERVE_MS,
   SEMANTIC_TRANSPORT_FALLBACK_RESERVE_MS,
   TransportFallbackMultimodalJudgeProvider,
   TransportFallbackSemanticProvider,
@@ -365,6 +366,65 @@ describe("TransportFallbackSemanticProvider", () => {
 });
 
 describe("TransportFallbackMultimodalJudgeProvider", () => {
+  it("reserves two minutes for the fallback inside a five-minute judge deadline", async () => {
+    const start = new Date("2026-08-18T12:00:00.000Z");
+    const context = {
+      ...judgeContext(),
+      deadlineAt: new Date(start.getTime() + 5 * 60_000),
+    };
+    const primary = stubJudgeProvider(
+      {
+        provider: "openrouter",
+        model: "stealth/ox-alpha",
+        visionModel: "stealth/ox-alpha",
+      },
+      (primaryContext) => {
+        expect(primaryContext.deadlineAt).toEqual(
+          new Date(
+            context.deadlineAt.getTime() -
+              MULTIMODAL_TRANSPORT_FALLBACK_RESERVE_MS,
+          ),
+        );
+        throw new ProviderError(
+          "PROVIDER_TIMEOUT",
+          "retryable",
+          "Multimodal provider exhausted its stream idle timeout budget",
+          {
+            telemetry: {
+              lastFailureKind: "timeout",
+              httpStatusClass: null,
+              transportAttemptCount: 1,
+            },
+          },
+        );
+      },
+    );
+    const fallback = stubJudgeProvider(
+      {
+        provider: "hetzner-inference",
+        model: "hetzner-judge",
+        visionModel: "hetzner-vision",
+      },
+      (fallbackContext) => {
+        expect(fallbackContext.deadlineAt).toEqual(context.deadlineAt);
+        return judgeResult({
+          provider: "hetzner-inference",
+          model: "hetzner-judge",
+        });
+      },
+    );
+
+    const result = await new TransportFallbackMultimodalJudgeProvider(
+      primary,
+      fallback,
+      { now: () => start.getTime() },
+    ).evaluate({} as MultimodalJudgeProviderInputV1, context);
+
+    expect(result.metadata.provider).toBe("hetzner-inference");
+    expect(primary.evaluate).toHaveBeenCalledOnce();
+    expect(fallback.evaluate).toHaveBeenCalledOnce();
+  });
+
   it("records the Hetzner judge after a primary transport failure", async () => {
     const primary = stubJudgeProvider(
       {
@@ -631,13 +691,13 @@ function stubSemanticProvider(
 
 function stubJudgeProvider(
   descriptor: InlineMultimodalJudgeProvider["descriptor"],
-  evaluate: () => MultimodalJudgeProviderResultV1,
+  evaluate: (context: ProviderContextV1) => MultimodalJudgeProviderResultV1,
 ): InlineMultimodalJudgeProvider & {
   evaluate: ReturnType<typeof vi.fn>;
 } {
   return {
     descriptor,
-    evaluate: vi.fn(async () => evaluate()),
+    evaluate: vi.fn(async (_input, context) => evaluate(context)),
   };
 }
 

--- a/packages/providers/src/transport-fallback.ts
+++ b/packages/providers/src/transport-fallback.ts
@@ -15,7 +15,7 @@ import type {
   MultimodalJudgeProviderInputV1,
   MultimodalJudgeProviderResultV1,
 } from "./hetzner-multimodal";
-import type { ProviderContextV1 } from "./contracts";
+import { ProviderContextV1Schema, type ProviderContextV1 } from "./contracts";
 
 type RepairableSemanticProvider<TInput> = {
   readonly descriptor: SemanticProviderDescriptorV1;
@@ -34,6 +34,14 @@ export const SEMANTIC_TRANSPORT_FALLBACK_RESERVE_MS = 120_000;
 export const SEMANTIC_TRANSPORT_FALLBACK_MIN_PRIMARY_MS = 30_000;
 
 export type TransportFallbackSemanticOptions = {
+  now?: () => number;
+  reserveMs?: number;
+};
+
+export const MULTIMODAL_TRANSPORT_FALLBACK_RESERVE_MS = 120_000;
+export const MULTIMODAL_TRANSPORT_FALLBACK_MIN_PRIMARY_MS = 60_000;
+
+export type TransportFallbackMultimodalOptions = {
   now?: () => number;
   reserveMs?: number;
 };
@@ -140,21 +148,36 @@ export class TransportFallbackSemanticProvider<
 export class TransportFallbackMultimodalJudgeProvider implements InlineMultimodalJudgeProvider {
   readonly descriptor: InlineMultimodalJudgeDescriptorV1;
   readonly transportFallbackDescriptor: InlineMultimodalJudgeDescriptorV1;
+  private readonly now: () => number;
+  private readonly reserveMs: number;
 
   constructor(
     private readonly primary: InlineMultimodalJudgeProvider,
     private readonly fallback: InlineMultimodalJudgeProvider,
+    options: TransportFallbackMultimodalOptions = {},
   ) {
     this.descriptor = primary.descriptor;
     this.transportFallbackDescriptor = fallback.descriptor;
+    this.now = options.now ?? Date.now;
+    this.reserveMs =
+      options.reserveMs ?? MULTIMODAL_TRANSPORT_FALLBACK_RESERVE_MS;
   }
 
   async evaluate(
     input: MultimodalJudgeProviderInputV1,
     context: ProviderContextV1,
   ): Promise<MultimodalJudgeProviderResultV1> {
+    const primaryContext = ProviderContextV1Schema.parse({
+      ...context,
+      deadlineAt: reserveTransportFallbackDeadline(
+        context.deadlineAt,
+        this.now(),
+        this.reserveMs,
+        MULTIMODAL_TRANSPORT_FALLBACK_MIN_PRIMARY_MS,
+      ),
+    });
     try {
-      return await this.primary.evaluate(input, context);
+      return await this.primary.evaluate(input, primaryContext);
     } catch (error) {
       if (!isTransportFailure(error)) {
         throw annotateProviderErrorHopUsed(error, "primary");


### PR DESCRIPTION
## Summary

- stream OpenAI-compatible multimodal judge responses over bounded SSE instead of waiting for one non-streaming JSON body
- treat content and private reasoning deltas as liveness without persisting reasoning, while retaining the absolute provider-hop deadline
- give the OpenRouter primary three minutes of the existing five-minute judge budget and reserve two minutes for the Hetzner transport fallback
- distinguish an exhausted stream-idle budget as `PROVIDER_TIMEOUT`; keep `DEADLINE_EXCEEDED` for the actual provider-hop deadline
- preserve the existing one-repair limit, transport-only fallback policy, response byte/event caps, strict binding validation, and manual maintainer authority

## Why

The first live Ox judge run ended after roughly 122 seconds even though the pipeline owns a five-minute deadline. The shared multimodal adapter used three non-streaming 20-second attempts for OpenRouter and then the same three attempts for Hetzner. Exhausting those attempt timers was also mislabeled as the overall deadline.

## Verification

- `pnpm verify`
  - 103 test files / 873 tests
  - lint, typecheck, builds, release audits, production contracts, boundary/doc/secret/history audits all passed
  - two existing production-image inspections skipped without `SLOPPROOF_IMAGE`; one existing encrypted-key backup helper skipped
- focused provider/factory suite: 4 files / 97 tests
- value-free live OpenRouter `stealth/ox-alpha` smoke returned HTTP 200 with `text/event-stream`, reasoning deltas, fenced JSON content, usage, and `[DONE]`; no repository, proof, transcript, frame, or contributor data was sent

## Scope

This branch starts from `main`. PR #20 and its branch were not modified, rebased, or pushed.
