### PR TITLE
fix: harden MiMo judge reliability

### DIFF
--- a/apps/worker/src/multimodal-judge-service.test.ts
+++ b/apps/worker/src/multimodal-judge-service.test.ts
@@ -106,6 +106,48 @@ describe("multimodal judge service", () => {
     expect(result.manualReviewRequired).toBe(true);
   });
 
+  it("routes missing question-bound transcript evidence to review without loading frames or invoking the provider", async () => {
+    const input = inputFixture();
+    input.transcript.segments[0] = {
+      ...input.transcript.segments[0]!,
+      questionId: undefined,
+    };
+    const provider = successfulProvider();
+    const loadFrames = vi.fn();
+
+    const result = await runMultimodalJudgeEvaluation(input, contextFixture(), {
+      provider,
+      loadFrames,
+      now: () => NOW,
+    });
+
+    expect(loadFrames).not.toHaveBeenCalled();
+    expect(provider.evaluate).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      workflowOutcome: "review_required",
+      manualReviewRequired: true,
+      frameWarnings: [],
+      frameCount: 0,
+      invocationMetadata: {
+        invocationCount: 0,
+        outcome: "fallback",
+        degraded: true,
+      },
+      candidate: {
+        recommendation: "review_required",
+        privateReason: "automated_evaluation_unavailable",
+        warnings: ["question_transcript_unavailable"],
+      },
+    });
+    expect(result.candidate.questionEvaluations[0]?.criterionResults).toEqual([
+      expect.objectContaining({
+        result: "not_evaluable",
+        supportedPatchAnchorIds: [],
+        reason: "question_evidence_unavailable",
+      }),
+    ]);
+  });
+
   it("invokes the provider after a non-deadline frame-loader failure", async () => {
     const provider = successfulProvider();
     const result = await runMultimodalJudgeEvaluation(

--- a/apps/worker/src/multimodal-judge-service.ts
+++ b/apps/worker/src/multimodal-judge-service.ts
@@ -65,6 +65,35 @@ export async function runMultimodalJudgeEvaluation(
   }
   assertBeforeMultimodalDeadline(context.data, requestStartedAt);
 
+  if (!hasCompleteQuestionBoundTranscriptEvidence(evaluationInput.data)) {
+    const completedAt = now();
+    assertBeforeMultimodalDeadline(context.data, completedAt);
+    const providerInput = projectMultimodalJudgeProviderInputV1(
+      evaluationInput.data,
+      [],
+    );
+    const providerResult = manualReviewFallbackMultimodalJudgeResultV1(
+      providerInput,
+      dependencies.provider.descriptor,
+      ["question_transcript_unavailable"],
+      completedAt,
+    );
+    return MultimodalProofEvaluationV1Schema.parse({
+      schemaVersion: "1",
+      evaluationVersion: "multimodal-proof-evaluation-v1",
+      attemptId: evaluationInput.data.attemptId,
+      revisionId: evaluationInput.data.revisionId,
+      headSha: evaluationInput.data.headSha,
+      candidate: providerResult.candidate,
+      invocationMetadata: providerResult.metadata,
+      frameWarnings: [],
+      frameCount: 0,
+      workflowOutcome: "review_required",
+      manualReviewRequired: true,
+      createdAt: completedAt,
+    });
+  }
+
   const loadFrames = resolveFrameLoader(dependencies);
   let rawLoadedFrames: unknown;
   try {
@@ -243,6 +272,21 @@ export function projectMultimodalJudgeProviderInputV1(
     },
     frames,
   });
+}
+
+function hasCompleteQuestionBoundTranscriptEvidence(
+  evaluationInput: ProofEvaluationInputV1,
+): boolean {
+  const questionIdsWithTranscriptEvidence = new Set(
+    evaluationInput.transcript.segments.flatMap((segment) =>
+      segment.questionId !== undefined && segment.text.content.trim().length > 0
+        ? [segment.questionId]
+        : [],
+    ),
+  );
+  return evaluationInput.questions.every((question) =>
+    questionIdsWithTranscriptEvidence.has(question.id),
+  );
 }
 
 function resolveFrameLoader(

--- a/docs/operations/production-configuration.md
+++ b/docs/operations/production-configuration.md
@@ -155,6 +155,20 @@ rate-limit failures. Invalid model output stays on the provider that
 produced it. Persisted provider/model metadata names the provider that
 answered. Transcription stays OpenRouter Whisper.
 
+The OpenRouter MiMo judge request keeps a bounded 6,000-token completion
+budget, disables model reasoning, excludes reasoning deltas, and requires an
+endpoint that supports every requested parameter. It also requests denied data
+collection and zero-data-retention routing. A larger output budget is not an
+availability control: reasoning-capable endpoints can otherwise consume the
+budget without producing the bounded JSON candidate. Any finish reason other
+than `stop` fails closed with a safe protocol subtype.
+
+Before frames are loaded or a judge provider is called, the Worker requires at
+least one non-empty question-bound transcript segment for every stored proof
+question. Missing question evidence is projected deterministically to
+`review_required`; patch anchors are never treated as evidence that the
+contributor explained or understood the change.
+
 ## Provider capability checks
 
 The following scripts make real, potentially billable requests and therefore

--- a/docs/privacy/provider-data-flow.md
+++ b/docs/privacy/provider-data-flow.md
@@ -1,23 +1,26 @@
 # Privacy and external provider data flow
 
-Stand: 2026-08-13
+Stand: 2026-08-24
 
 This document describes implemented technical minimization. It is not a claim
 that a third-party provider has contractually guaranteed zero-data retention.
 Operators must verify current terms, region, subprocessors and account settings
 before enabling production.
 
-| Recipient         | Sent                                                                                                                                                                                                    | Explicitly not sent                                                                                                                                  | Persistence in SlopProof                                                                            |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| GitHub            | App/OAuth protocol data, repository/PR identity, bounded patch and exact tree metadata, public Check state                                                                                              | Evidence, transcript, frames, answers, provider reasoning                                                                                            | Installation/repository/PR/revision metadata and content-free check intent                          |
-| Cloudflare R2     | Browser-encrypted recording objects and Worker-encrypted frame derivatives                                                                                                                              | Plaintext recording, transcript, model output, RSA private key                                                                                       | Private bucket until canonical `delete_after`; application deletion plus storage lifecycle backstop |
-| OpenRouter STT    | One bounded per-question mono 16-kHz WAV after Worker-only decryption                                                                                                                                   | Full video, other answers, patch, repository, author identity, public object URL                                                                     | Only encrypted question-bound transcript is stored by SlopProof                                     |
-| Hetzner inference | For generation: bounded untrusted patch context. For Judge: exact head SHA, stored questions/rubrics, bounded anchors, question-bound transcript, timing and at most four inline normalized JPEG frames | Full video, public Evidence URL, GitHub/OAuth identity, face/person metadata, room/accent/disability/tool-analysis fields, Practice answers in Proof | Learning/Practice/Judge artifacts are encrypted worker-only; the public Check has none              |
+| Recipient         | Sent                                                                                                                                                 | Explicitly not sent                                                                                                                                  | Persistence in SlopProof                                                                            |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| GitHub            | App/OAuth protocol data, repository/PR identity, bounded patch and exact tree metadata, public Check state                                           | Evidence, transcript, frames, answers, provider reasoning                                                                                            | Installation/repository/PR/revision metadata and content-free check intent                          |
+| Cloudflare R2     | Browser-encrypted recording objects and Worker-encrypted frame derivatives                                                                           | Plaintext recording, transcript, model output, RSA private key                                                                                       | Private bucket until canonical `delete_after`; application deletion plus storage lifecycle backstop |
+| OpenRouter STT    | One bounded per-question mono 16-kHz WAV after Worker-only decryption                                                                                | Full video, other answers, patch, repository, author identity, public object URL                                                                     | Only encrypted question-bound transcript is stored by SlopProof                                     |
+| OpenRouter judge  | Exact head SHA, stored questions/rubrics, bounded anchors, complete question-bound transcript, timing and at most four inline normalized JPEG frames | Full video, public Evidence URL, GitHub/OAuth identity, face/person metadata, room/accent/disability/tool-analysis fields, Practice answers in Proof | Encrypted authoritative judge sidecar and compatibility projection; the public Check has none       |
+| Hetzner inference | Bounded untrusted patch context for generation; the same minimized judge material only after an eligible transport fallback                          | Full video, public Evidence URL, GitHub/OAuth identity, face/person metadata, room/accent/disability/tool-analysis fields, Practice answers in Proof | Learning/Practice/Judge artifacts are encrypted worker-only; the public Check has none              |
 
 Provider calls disable tools and request `store=false` where the endpoint
-supports it. Requests and responses have absolute deadlines and byte caps;
-transport retry is limited to rate limit, server, network and timeout classes.
-Raw provider bodies and errors are never logged.
+supports it. OpenRouter judge routing additionally requires supported request
+parameters, denied data collection and a ZDR-capable endpoint. Requests and
+responses have absolute deadlines and byte caps; transport retry is limited to
+rate limit, server, network, stream and timeout classes. Raw provider bodies and
+errors are never logged.
 
 ## Retention and access
 

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,6 +1,6 @@
 # Production threat model
 
-Stand: 2026-08-13
+Stand: 2026-08-24
 
 ## Security objectives
 
@@ -24,23 +24,23 @@ Stand: 2026-08-13
   deadline;
 - decrypted audio/frames/transcript and encrypted semantic/judge sidecars;
 - PostgreSQL, pg-boss, backups, logs and deployment secrets;
-- external boundaries: GitHub, Cloudflare R2, Hetzner inference, OpenRouter STT,
-  host Caddy, Docker and the operator workstation.
+- external boundaries: GitHub, Cloudflare R2, Hetzner inference, OpenRouter
+  inference/STT, host Caddy, Docker and the operator workstation.
 
 ## Principal threats and controls
 
-| Threat                           | Primary controls                                                                                                                | Residual risk                                                                         |
-| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| Forged webhook or OAuth callback | Raw-body HMAC, exact event schemas, PKCE/state, one-time DB state, proxy-authenticated client IP                                | GitHub/operator credential compromise                                                 |
-| Stale SHA or lifecycle race      | Current revision locks, PR/repo/install active fences before and after private effects, durable invalidation                    | External event delay before next authoritative read                                   |
-| Replay/crash duplicates          | Immutable hashes, exact replay comparison, transactional pg-boss upsert/heal, sweepers                                          | Provider may have accepted a request before a network ambiguity; outcome stays manual |
-| Evidence disclosure from storage | Browser AEAD, worker-only RSA unwrap, strict object keys/AAD/hash, R2 private bucket                                            | Worker host/private key compromise                                                    |
-| Prompt injection/model overreach | Untrusted wrappers, strict IDs/anchors/codes, bounded provider material, no tools, one repair, deterministic/manual fallback    | Provider sees the minimal material required for its task                              |
-| Biometric/person/tool inference  | Provider input excludes identity metadata; structured output has no free person-analysis field; forbidden semantics fail closed | Visual frames inherently depict the contributor and surroundings                      |
-| DoS and cost exhaustion          | Body/media/provider byte caps, duration/question caps, durable HMAC quotas, deadlines, retries, CPU/RAM/PID limits              | Distributed traffic and upstream provider outage still require operator response      |
-| Log/metric leakage               | Allowlisted value-free fields, Pino redaction, Caddy query/header/IP filters, no payload metrics                                | Operator debug changes can reintroduce leakage and require review                     |
-| Supply-chain compromise          | Frozen lockfile, boundary/secret audit, SBOM, dependency review, image vulnerability scan, non-root/read-only runtime           | CI/action and base-image trust; actions are commit-pinned                             |
-| Database/backup theft            | Provider/evidence payload encryption, protected DB network and encrypted backup handling                                        | Repository metadata and access patterns remain sensitive                              |
+| Threat                           | Primary controls                                                                                                                                                         | Residual risk                                                                         |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
+| Forged webhook or OAuth callback | Raw-body HMAC, exact event schemas, PKCE/state, one-time DB state, proxy-authenticated client IP                                                                         | GitHub/operator credential compromise                                                 |
+| Stale SHA or lifecycle race      | Current revision locks, PR/repo/install active fences before and after private effects, durable invalidation                                                             | External event delay before next authoritative read                                   |
+| Replay/crash duplicates          | Immutable hashes, exact replay comparison, transactional pg-boss upsert/heal, sweepers                                                                                   | Provider may have accepted a request before a network ambiguity; outcome stays manual |
+| Evidence disclosure from storage | Browser AEAD, worker-only RSA unwrap, strict object keys/AAD/hash, R2 private bucket                                                                                     | Worker host/private key compromise                                                    |
+| Prompt injection/model overreach | Untrusted wrappers, strict IDs/anchors/codes, bounded provider material, no tools, one repair, complete per-question transcript preflight, deterministic/manual fallback | Provider sees the minimal material required for its task                              |
+| Biometric/person/tool inference  | Provider input excludes identity metadata; structured output has no free person-analysis field; forbidden semantics fail closed                                          | Visual frames inherently depict the contributor and surroundings                      |
+| DoS and cost exhaustion          | Body/media/provider byte caps, duration/question caps, durable HMAC quotas, deadlines, retries, CPU/RAM/PID limits                                                       | Distributed traffic and upstream provider outage still require operator response      |
+| Log/metric leakage               | Allowlisted value-free fields, Pino redaction, Caddy query/header/IP filters, no payload metrics                                                                         | Operator debug changes can reintroduce leakage and require review                     |
+| Supply-chain compromise          | Frozen lockfile, boundary/secret audit, SBOM, dependency review, image vulnerability scan, non-root/read-only runtime                                                    | CI/action and base-image trust; actions are commit-pinned                             |
+| Database/backup theft            | Provider/evidence payload encryption, protected DB network and encrypted backup handling                                                                                 | Repository metadata and access patterns remain sensitive                              |
 
 ## Explicit non-goals
 

--- a/packages/providers/src/contracts.ts
+++ b/packages/providers/src/contracts.ts
@@ -405,8 +405,10 @@ const AuthoritativeWarningCodeV1Schema = z.enum([
   "frame_jpeg_invalid",
   "frame_dimensions_invalid",
   "provider_evaluation_unavailable",
+  "question_transcript_unavailable",
   "local_fake_manual_review",
   "incoherent_pass_normalized_downward",
+  "incoherent_retry_normalized_downward",
 ]);
 
 const AuthoritativeFrameWarningCodeV1Schema = z.enum([

--- a/packages/providers/src/errors.ts
+++ b/packages/providers/src/errors.ts
@@ -19,9 +19,13 @@ export type ProviderErrorDisposition = "retryable" | "terminal" | "review";
 export const PROVIDER_FAILURE_KINDS = [
   "deadline_exceeded",
   "invalid_output",
+  "malformed_response",
   "network",
+  "output_truncated",
   "rate_limited",
   "request_rejected",
+  "response_stream",
+  "response_too_large",
   "timeout",
   "upstream_unavailable",
 ] as const;
@@ -51,6 +55,8 @@ export const PROVIDER_VALIDATION_ISSUE_CODES = [
   "missing_criterion",
   "missing_question",
   "pass_with_unresolved_or_nonpassing",
+  "retry_with_unresolved_evidence",
+  "private_reason_mismatch",
 ] as const;
 
 export type ProviderValidationIssueCode =
@@ -146,6 +152,7 @@ const TRANSPORT_FAILURE_KINDS = new Set<ProviderFailureKind>([
   "deadline_exceeded",
   "network",
   "rate_limited",
+  "response_stream",
   "timeout",
   "upstream_unavailable",
 ]);

--- a/packages/providers/src/hetzner-multimodal.test.ts
+++ b/packages/providers/src/hetzner-multimodal.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   HetznerMultimodalJudgeProvider,
   LocalFakeInlineMultimodalJudgeProvider,
+  MULTIMODAL_JUDGE_MAXIMUM_OUTPUT_TOKENS,
   PROOF_JUDGE_SYSTEM_V2,
   manualReviewFallbackCandidateV1,
   validateMultimodalJudgeCandidateV1,
@@ -58,6 +59,8 @@ describe("HetznerMultimodalJudgeProvider", () => {
       chat_template_kwargs: { thinking: false },
     });
     expect(bodies[0]).not.toHaveProperty("tools");
+    expect(bodies[0]).not.toHaveProperty("reasoning");
+    expect(bodies[0]).not.toHaveProperty("provider");
     expect(bodies[0]).not.toHaveProperty("response_format");
     const imagePart = (
       bodies[0] as {
@@ -108,6 +111,12 @@ describe("HetznerMultimodalJudgeProvider", () => {
     );
     expect(PROOF_JUDGE_SYSTEM_V2).toContain(
       "Recommend review_required when any criterion is not_evaluable",
+    );
+    expect(PROOF_JUDGE_SYSTEM_V2).toContain(
+      "Patch anchors define the correct change but never prove",
+    );
+    expect(PROOF_JUDGE_SYSTEM_V2).toContain(
+      "Never infer a missing spoken answer",
     );
   });
 
@@ -225,11 +234,21 @@ describe("HetznerMultimodalJudgeProvider", () => {
       expect(fetchImpl).toHaveBeenCalledTimes(2);
       const first = JSON.parse(String(fetchImpl.mock.calls[0]?.[1]?.body)) as {
         model: string;
+        max_tokens: number;
         tools: unknown;
+        reasoning: unknown;
+        provider: unknown;
         response_format: { type: string };
       };
       expect(first.model).toBe("text-model");
+      expect(first.max_tokens).toBe(MULTIMODAL_JUDGE_MAXIMUM_OUTPUT_TOKENS);
       expect(first.tools).toEqual([]);
+      expect(first.reasoning).toEqual({ effort: "none", exclude: true });
+      expect(first.provider).toEqual({
+        require_parameters: true,
+        data_collection: "deny",
+        zdr: true,
+      });
       expect(first.response_format.type).toBe("json_schema");
       expect(JSON.parse(String(fetchImpl.mock.calls[1]?.[1]?.body)).model).toBe(
         "vision-model",
@@ -490,6 +509,97 @@ describe("HetznerMultimodalJudgeProvider", () => {
       privateReason: "stored_criteria_not_fully_supported",
       warnings: expect.arrayContaining(["incoherent_pass_normalized_downward"]),
     });
+  });
+
+  it("normalizes retry with unresolved evidence to maintainer review", () => {
+    const unresolvedRetry = manualReviewFallbackCandidateV1(inputFixture());
+    unresolvedRetry.recommendation = "retry";
+    unresolvedRetry.privateReason = "stored_criteria_not_fully_supported";
+
+    expect(
+      validateMultimodalJudgeCandidateV1(unresolvedRetry, inputFixture()),
+    ).toMatchObject({
+      recommendation: "review_required",
+      privateReason: "stored_criteria_not_fully_supported",
+      warnings: expect.arrayContaining([
+        "incoherent_retry_normalized_downward",
+      ]),
+    });
+  });
+
+  it("normalizes a provider-only private reason mismatch without changing a safe recommendation", () => {
+    const mismatched = validCandidate();
+    mismatched.privateReason = "stored_criteria_not_fully_supported";
+
+    expect(
+      validateMultimodalJudgeCandidateV1(mismatched, inputFixture()),
+    ).toMatchObject({
+      recommendation: "pass",
+      privateReason: "all_stored_criteria_supported",
+    });
+  });
+
+  it("classifies a length finish reason as truncated output before JSON repair", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(completionWithFinishReason("{", "length"));
+
+    await expect(
+      providerWith(fetchImpl, { maxAttempts: 1 }).evaluate(
+        { ...inputFixture(), frames: [] },
+        contextFixture(),
+      ),
+    ).rejects.toMatchObject({
+      code: "INVALID_OUTPUT",
+      disposition: "review",
+      telemetry: {
+        lastFailureKind: "output_truncated",
+        transportAttemptCount: 1,
+      },
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("preserves the bounded response-too-large subtype", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(completionResponse(validCandidate()));
+
+    await expect(
+      providerWith(fetchImpl, {
+        maxAttempts: 1,
+        maxResponseBytes: 64,
+      }).evaluate({ ...inputFixture(), frames: [] }, contextFixture()),
+    ).rejects.toMatchObject({
+      code: "INVALID_OUTPUT",
+      disposition: "review",
+      telemetry: {
+        lastFailureKind: "response_too_large",
+        transportAttemptCount: 1,
+      },
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+  });
+
+  it("keeps an exhausted mid-stream failure transport-hop eligible", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(brokenStreamResponse());
+
+    await expect(
+      providerWith(fetchImpl, { maxAttempts: 1 }).evaluate(
+        { ...inputFixture(), frames: [] },
+        contextFixture(),
+      ),
+    ).rejects.toMatchObject({
+      code: "PROVIDER_UNAVAILABLE",
+      disposition: "retryable",
+      telemetry: {
+        lastFailureKind: "response_stream",
+        transportAttemptCount: 1,
+      },
+    });
+    expect(fetchImpl).toHaveBeenCalledOnce();
   });
 
   it("normalizes an incoherent pass over bounded negative findings to retry", async () => {
@@ -1252,6 +1362,36 @@ function validCandidate(): MultimodalJudgeCandidateV1 {
 
 function completionResponse(candidate: unknown): Response {
   return completionTextResponse(JSON.stringify({ result: candidate }));
+}
+
+function completionWithFinishReason(
+  content: string,
+  finishReason: string,
+): Response {
+  const events = [
+    { choices: [{ delta: { content }, finish_reason: null }] },
+    { choices: [{ delta: {}, finish_reason: finishReason }] },
+  ];
+  return new Response(
+    `${events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("")}data: [DONE]\n\n`,
+    { headers: { "content-type": "text/event-stream" } },
+  );
+}
+
+function brokenStreamResponse(): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          new TextEncoder().encode(
+            `data: ${JSON.stringify({ choices: [{ delta: { content: "{" }, finish_reason: null }] })}\n\n`,
+          ),
+        );
+        controller.error(new Error("private stream failure"));
+      },
+    }),
+    { headers: { "content-type": "text/event-stream" } },
+  );
 }
 
 function completionTextResponse(content: string): Response {

--- a/packages/providers/src/hetzner-multimodal.ts
+++ b/packages/providers/src/hetzner-multimodal.ts
@@ -26,6 +26,7 @@ const MAX_SSE_EVENT_BYTES = 256 * 1_024;
 const MAX_SSE_EVENT_COUNT = 20_000;
 const MAX_INLINE_FRAME_BYTES = 512 * 1_024;
 const MAX_INLINE_FRAME_TOTAL_BYTES = 2 * 1_024 * 1_024;
+export const MULTIMODAL_JUDGE_MAXIMUM_OUTPUT_TOKENS = 6_000;
 const VISION_CAPABILITY_REJECTED_STATUSES = new Set([400, 404, 415, 422]);
 const timeoutMarker = Symbol("hetzner-multimodal-timeout");
 
@@ -279,7 +280,9 @@ export const MultimodalWarningCodeV1Schema = z.enum([
   "frame_dimensions_invalid",
   "provider_evaluation_unavailable",
   "local_fake_manual_review",
+  "question_transcript_unavailable",
   "incoherent_pass_normalized_downward",
+  "incoherent_retry_normalized_downward",
 ]);
 
 export type MultimodalWarningCodeV1 = z.infer<
@@ -431,7 +434,8 @@ type ResolvedRequestPolicy = {
 };
 
 type RetryableFailure = {
-  kind: "network" | "timeout" | "rate_limited" | "unavailable";
+  kind:
+    "network" | "timeout" | "rate_limited" | "unavailable" | "response_stream";
   retryAfterMs?: number;
   httpStatus?: number;
   httpStatusClass?: ProviderHttpStatusClass;
@@ -662,6 +666,15 @@ export class HetznerMultimodalJudgeProvider implements InlineMultimodalJudgeProv
       policy: this.policy,
       allowVisionCapabilityFallback,
     });
+    if (streamed.finishReason !== "stop") {
+      throw invalidOutputError(
+        streamed.transportAttemptCount,
+        undefined,
+        streamed.finishReason === "length"
+          ? "output_truncated"
+          : "malformed_response",
+      );
+    }
     const extracted =
       typeof streamed.content === "string"
         ? tryExtractJsonObject(streamed.content)
@@ -799,21 +812,58 @@ export function validateMultimodalJudgeCandidateV1(
   ) {
     issues.add("pass_with_unresolved_or_nonpassing");
   }
-  if (issues.size === 1 && issues.has("pass_with_unresolved_or_nonpassing")) {
+  if (
+    candidate.data.recommendation === "retry" &&
+    (hasNotEvaluableResult || hasUnresolvedEvidence)
+  ) {
+    issues.add("retry_with_unresolved_evidence");
+  }
+  const expectedPrivateReason =
+    candidate.data.recommendation === "pass"
+      ? "all_stored_criteria_supported"
+      : "stored_criteria_not_fully_supported";
+  if (candidate.data.privateReason !== expectedPrivateReason) {
+    issues.add("private_reason_mismatch");
+  }
+  const normalizableIssues = new Set<ProviderValidationIssueCode>([
+    "pass_with_unresolved_or_nonpassing",
+    "retry_with_unresolved_evidence",
+    "private_reason_mismatch",
+  ]);
+  if (
+    issues.size > 0 &&
+    [...issues].every((issue) => normalizableIssues.has(issue))
+  ) {
     const normalizedRecommendation =
-      hasNotMetResult && !hasNotEvaluableResult && !hasUnresolvedEvidence
-        ? "retry"
-        : "review_required";
+      hasNotEvaluableResult || hasUnresolvedEvidence
+        ? "review_required"
+        : hasNotMetResult
+          ? "retry"
+          : candidate.data.recommendation;
+    const normalizationWarning =
+      candidate.data.recommendation === "pass" &&
+      normalizedRecommendation !== "pass"
+        ? "incoherent_pass_normalized_downward"
+        : candidate.data.recommendation === "retry" &&
+            normalizedRecommendation === "review_required"
+          ? "incoherent_retry_normalized_downward"
+          : undefined;
     return MultimodalJudgeCandidateV1Schema.parse({
       ...candidate.data,
       recommendation: normalizedRecommendation,
-      privateReason: "stored_criteria_not_fully_supported",
-      warnings: [
-        "incoherent_pass_normalized_downward",
-        ...candidate.data.warnings.filter(
-          (warning) => warning !== "incoherent_pass_normalized_downward",
-        ),
-      ].slice(0, 20),
+      privateReason:
+        normalizedRecommendation === "pass"
+          ? "all_stored_criteria_supported"
+          : "stored_criteria_not_fully_supported",
+      warnings:
+        normalizationWarning === undefined
+          ? candidate.data.warnings
+          : [
+              normalizationWarning,
+              ...candidate.data.warnings.filter(
+                (warning) => warning !== normalizationWarning,
+              ),
+            ].slice(0, 20),
     });
   }
   if (issues.size > 0) {
@@ -963,6 +1013,8 @@ export const PROOF_JUDGE_SYSTEM_V2 = [
   "You may use the frames only for help versus no-help: a second screen, notes, or reading off a device. That is why the frames are supplied.",
   "Never identify or characterize a person. Never analyze identity, gaze as identity, disability, or authorship. Do not describe a face, age, gender, race, or who the speaker is.",
   "Never invoke tools or browse. Cite only supplied anchor IDs.",
+  "Judge the understanding shown only from the question-bound transcript evidence. Patch anchors define the correct change but never prove that the speaker explained or understood it.",
+  "Never infer a missing spoken answer from the patch, question, rubric, timing or frames. If question-bound transcript evidence is absent or insufficient, mark every affected criterion not_evaluable.",
   "Return every supplied question ID and every criterion ID exactly once; do not add, omit or rewrite criteria.",
   "For met use one or more anchors from that question and reason patch_evidence_supports_criterion. For not_met use one or more anchors from that question and reason patch_evidence_conflicts_with_criterion.",
   "For not_evaluable use no anchors and reason question_evidence_insufficient or question_evidence_unavailable. Never attach an anchor to not_evaluable.",
@@ -1018,10 +1070,18 @@ function buildRequestBody(
     store: false,
     stream: true,
     temperature: 0,
-    max_tokens: 6_000,
+    max_tokens: MULTIMODAL_JUDGE_MAXIMUM_OUTPUT_TOKENS,
     ...(hetzner
       ? { chat_template_kwargs: { thinking: false } }
-      : { tools: [] }),
+      : {
+          tools: [],
+          reasoning: { effort: "none", exclude: true },
+          provider: {
+            require_parameters: true,
+            data_collection: "deny",
+            zdr: true,
+          },
+        }),
     ...(includeStructuredOutput
       ? {
           response_format: {
@@ -1126,9 +1186,9 @@ async function requestStreamWithRetry(input: {
       }
       if (error instanceof SafeProtocolError) {
         if (error.kind === "response_stream") {
-          lastFailure = { kind: "network" };
+          lastFailure = { kind: "response_stream" };
         } else {
-          throw invalidOutputError();
+          throw invalidOutputError(attempt, undefined, error.kind);
         }
       } else if (isResponseStatusMarker(error)) {
         try {
@@ -1632,6 +1692,11 @@ function invalidInputError(): ProviderError {
 function invalidOutputError(
   invocationCount = 1,
   validation?: CandidateValidationError,
+  failureKind:
+    | "invalid_output"
+    | "malformed_response"
+    | "output_truncated"
+    | "response_too_large" = "invalid_output",
 ): ProviderError {
   return new ProviderError(
     "INVALID_OUTPUT",
@@ -1640,7 +1705,7 @@ function invalidOutputError(
     {
       ...(validation === undefined ? {} : { cause: validation }),
       telemetry: {
-        lastFailureKind: "invalid_output",
+        lastFailureKind: failureKind,
         httpStatusClass: null,
         transportAttemptCount: invocationCount,
       },


### PR DESCRIPTION
## Summary

- make the OpenRouter MiMo 2.5 judge disable reasoning while retaining the bounded 6,000-token output budget
- require structured-output parameter support, denied data collection, and ZDR-capable routing
- fail closed to deterministic maintainer review before frame loading/provider invocation when any proof question lacks non-empty bound transcript evidence
- tighten recommendation/private-reason coherence without ever upgrading a provider recommendation
- preserve safe `output_truncated`, `response_too_large`, malformed-response, and mid-stream failure classifications
- document the provider, privacy, and threat-model boundaries

## Why

Live value-free reproductions showed that larger output limits are not the reliability fix. With provider-default reasoning, MiMo can consume the full output budget without producing candidate JSON and exceed the bounded SSE reader. With reasoning disabled and parameter-compatible routing, the exact strict judge schema completed reliably within roughly 800–1,000 completion tokens.

The same reproductions found a separate semantic boundary: a provider can infer a missing answer from patch anchors and emit a formally coherent pass. This change therefore rejects incomplete per-question transcript evidence before sending any material to the judge.

## Verification

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 103 files / 880 tests
- full `pnpm verify`, including release audits, provider/R2 smoke contracts, production compose/image/operations/deployment/backup contracts, builds, package-boundary/docs/secret/history audits

## Deployment note

Production promotion must compile `JUDGE_MODEL` and `JUDGE_FALLBACK_MODEL` as `xiaomi/mimo-v2.5`. This PR does not mutate production secrets, old attempts, or stored evidence.

PR #20 remains untouched and frozen at `5fe297965ef791eb2885d8c8eb157be23166a3ea`.
