### PR TITLE
Fix desktop product-tour image sizing

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -201,7 +201,7 @@
     .journey-slide { grid-area: 1 / 1; min-width: 0; min-height: 0; margin: 0; display: grid; grid-template-rows: minmax(0, 1fr) 104px; overflow: hidden; }
     .journey-slide[hidden] { display: none; }
     .journey-image { min-height: 0; padding: 18px; display: grid; place-items: center; background: var(--paper); overflow: hidden; }
-    .journey-image img { width: 100%; height: 100%; display: block; object-fit: contain; object-position: center; }
+    .journey-image img { width: 100%; height: 100%; min-width: 0; min-height: 0; display: block; object-fit: contain; object-position: center; }
     .journey-caption { min-height: 104px; padding: 20px 26px; display: grid; grid-template-columns: 92px 1fr; gap: 22px; align-items: center; border-top: var(--line); background: var(--sheet); color: var(--ink); }
     .journey-step { color: var(--orange); font: 650 11px/1 var(--mono); text-transform: uppercase; letter-spacing: .08em; }
     .journey-copy strong { display: block; font: 720 24px/1.05 var(--display); letter-spacing: -.02em; }

--- a/landing/source/index.html
+++ b/landing/source/index.html
@@ -201,7 +201,7 @@
     .journey-slide { grid-area: 1 / 1; min-width: 0; min-height: 0; margin: 0; display: grid; grid-template-rows: minmax(0, 1fr) 104px; overflow: hidden; }
     .journey-slide[hidden] { display: none; }
     .journey-image { min-height: 0; padding: 18px; display: grid; place-items: center; background: var(--paper); overflow: hidden; }
-    .journey-image img { width: 100%; height: 100%; display: block; object-fit: contain; object-position: center; }
+    .journey-image img { width: 100%; height: 100%; min-width: 0; min-height: 0; display: block; object-fit: contain; object-position: center; }
     .journey-caption { min-height: 104px; padding: 20px 26px; display: grid; grid-template-columns: 92px 1fr; gap: 22px; align-items: center; border-top: var(--line); background: var(--sheet); color: var(--ink); }
     .journey-step { color: var(--orange); font: 650 11px/1 var(--mono); text-transform: uppercase; letter-spacing: .08em; }
     .journey-copy strong { display: block; font: 720 24px/1.05 var(--display); letter-spacing: -.02em; }

--- a/scripts/lib/production-operations.test.mjs
+++ b/scripts/lib/production-operations.test.mjs
@@ -97,6 +97,10 @@ test("landing interactions obey the strict script policy and default to Proof", 
   assert.match(landing, /class="check-choice proof active"/u);
   assert.match(landing, /class="check-choice optional"/u);
   assert.match(landing, /aria-roledescription="carousel"/u);
+  assert.match(
+    landing,
+    /\.journey-image img \{[^}]*min-width: 0;[^}]*min-height: 0;[^}]*object-fit: contain;/u,
+  );
   assert.match(landing, /The real product · 9 steps/u);
   assert.match(landing, /Start with the GitHub App comment\./u);
   assert.match(landing, /Open the linked understanding check\./u);


### PR DESCRIPTION
## Change

Keep every product-tour image inside the carousel's fixed image track by resetting the replaced element's intrinsic grid minimums with `min-width: 0` and `min-height: 0`.

The source image was complete. On desktop, its intrinsic aspect ratio made the `<img>` grid item 867px tall inside a 595px content box, so the carousel's `overflow: hidden` clipped 272px from the bottom before `object-fit: contain` could help. The reset lets the image element take the bounded track size and makes `object-fit: contain` effective.

The published landing copy is regenerated byte-for-byte from `landing/source/index.html`. A production-operations contract now preserves the sizing reset.

No JavaScript, caching, Caddy, image asset, application route, or production state changes.

## Verification

- Chrome and Firefox: all 9 slides contained at 1914x1279, 1280x900, and 390x844
- Visual check of slide 2 confirms the complete source image, including both action buttons and explanatory text
- Node 24 `pnpm verify`: 104 test files / 892 tests, build and all release, boundary, documentation, and secret audits green
- `pnpm format:check`
- `git diff --check`
