### PR TITLE
Fix cached GitHub comment image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,14 @@ scoring.
 
 ## Product tour
 
-These production captures show the earlier SlopProof name. UnderstandProof is the
-same project; the captures have not been altered.
+The GitHub App comment shows the current interface. Some other production
+captures still show earlier branding; those historical captures remain unaltered.
 
 The flow starts where contributors already work. The GitHub App posts a
 revision-bound link directly on the pull request.
 
 <p align="center">
-  <img src="docs/assets/product-tour/github-comment.webp" width="920" alt="Automatic UnderstandProof GitHub App comment linking to the contributor flow">
+  <img src="docs/assets/product-tour/github-comment.webp?v=0964f60e8b5e" width="920" alt="Automatic UnderstandProof GitHub App comment linking to the contributor flow">
 </p>
 
 The contributor checks the camera and privacy terms, then answers the


### PR DESCRIPTION
## Change
- Version the README GitHub-comment image URL using the existing WebP content hash.
- Clarify that the comment is current while other captures remain historical.

## Evidence
The main-branch asset already contains the new capture, but GitHub’s unversioned raw/main route still returned the old 1760×654 image. The versioned URL returns the exact current 892×339 capture (SHA256 0964f60e8b5e2e1fa42a790ab539e8270acdc1d35efb4d2754d43f41172fd2b1).

## Verification
- Production operations: 10/10
- Prettier and git diff --check
- Live versioned-image SHA256 comparison

README-only; no application, landing deployment, binary asset, or required-check changes.
