### PR TITLE
Remove 'Beyond code' section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,6 @@ the current head SHA, so a new push requires a fresh explanation.
 </p>
 <p align="center"><sub>The contributor view for a pull request: Practice is optional. Proof is required.</sub></p>
 
-## Beyond code
-
-The long-term vision is **Proof of Understanding** for texts and other media,
-not only code. Those are future applications, not supported input types today.
-The current product is a GitHub pull-request understanding gate.
-
 ## How it works
 
 1. The GitHub App receives a pull-request event and binds a check to that head


### PR DESCRIPTION
Removed section discussing future applications beyond code.

## Change

Describe the behavior changed by this pull request.

## Failure mode

What can fail, and how does the change fail closed?

## Verification

- [ ] Unit or contract tests
- [ ] PostgreSQL integration tests when state or concurrency changed
- [ ] Playwright coverage when a user flow changed
- [ ] Threat model or provider data-flow update when a boundary changed
- [ ] `pnpm audit:secrets`
- [ ] No credentials, private repository data or evidence artifacts included

## Privacy and public output

List any new stored field, provider field, log field, metric label, HTTP route,
GitHub permission or Check output. Write `none` when the patch adds none.
