### PR TITLE
Rename the required GitHub check to UnderstandProof

### DIFF
--- a/apps/github-control/src/control.test.ts
+++ b/apps/github-control/src/control.test.ts
@@ -955,7 +955,7 @@ function claimedCheck() {
     checkRunId,
     attempt: 1,
     githubCheckRunId: null,
-    name: "SlopProof / understanding required",
+    name: "UnderstandProof / understanding required",
     status: "in_progress" as const,
     conclusion: null,
     publicSummary: "understanding required",

--- a/apps/web/app/demo/pr/[number]/page.tsx
+++ b/apps/web/app/demo/pr/[number]/page.tsx
@@ -51,7 +51,7 @@ export default async function PullRequestPage({
       </a>
       <div className="check-header">
         <div>
-          <p className="eyebrow">SlopProof / understanding required</p>
+          <p className="eyebrow">UnderstandProof / understanding required</p>
           <h1 className="flow-title">
             {pullRequest.risk_explanation.title ?? `PR #${String(number)}`}
           </h1>

--- a/apps/worker/src/revision-preparation.ts
+++ b/apps/worker/src/revision-preparation.ts
@@ -45,7 +45,7 @@ const ACTIVE_ATTEMPT_STATUSES = [
   "review_required",
 ] as const;
 
-const GITHUB_CHECK_NAME = "SlopProof / understanding required";
+const GITHUB_CHECK_NAME = "UnderstandProof / understanding required";
 
 export type WorkerCheckIntentWriterInput = {
   revisionId: string;

--- a/docs/maintainers/dogfooding.md
+++ b/docs/maintainers/dogfooding.md
@@ -14,7 +14,7 @@ as the expected status-check source after the App has submitted a recent check.
 2. Install the production GitHub App on this repository only.
 3. Open a small bootstrap pull request that changes documentation.
 4. Complete Practice, Live Proof and maintainer review.
-5. Confirm the check named `SlopProof / understanding required` completed on the
+5. Confirm the check named `UnderstandProof / understanding required` completed on the
    pull request's current head SHA.
 6. Record the GitHub App integration ID shown as the check source.
 7. Create the `main` ruleset described below.
@@ -31,7 +31,7 @@ Target `refs/heads/main` and enable:
 - require `ci / verify`;
 - require `supply-chain / dependency-audit`;
 - require `supply-chain / image-sbom-scan`;
-- require `SlopProof / understanding required` from the UnderstandProof GitHub App;
+- require `UnderstandProof / understanding required` from the UnderstandProof GitHub App;
 - require the branch to be current with `main`.
 
 The repository currently has one maintainer, so the ruleset must not require an

--- a/docs/operations/understandproof-rename.md
+++ b/docs/operations/understandproof-rename.md
@@ -39,11 +39,6 @@ compatibility contracts rather than the public brand:
 - **GitHub App identity:** The existing App now uses the installation URL
   `https://github.com/apps/understandproof`. Its numeric identity and existing
   installations remain unchanged; this is not a replacement App.
-- **Merge gate:** `SlopProof / understanding required` remains the exact check
-  name emitted by the application, stored in check rows, and required by
-  existing repository rulesets. The display name is deliberately not changed
-  independently of the rulesets. Check messages and PR comment copy can use
-  UnderstandProof while this gate remains stable.
 - **Repository policy:** `.slopproof.yml` remains the authoritative policy
   filename. No new filename or ambiguous dual-policy precedence is introduced.
 - **Authentication and protocol:** `slopproof_session`, other existing cookies,
@@ -86,9 +81,21 @@ does not deploy the renamed interface or static landing page.
    installations must retain their behavior.
 4. If the registered App is later renamed, preserve its identity/installations,
    verify the new installation URL, and update links only after it works.
-5. Treat the origin transition and any future required-check rename as coordinated migrations.
-   An origin move needs DNS/TLS, OAuth/webhook URLs, storage CORS, browser-origin
-   checks, and old-link handling verified together. A check rename needs the
-   emitter and consuming rulesets transitioned without a missing or fail-open
-   required gate. The hosted-origin transition is coordinated with deployment; the required-check
-   name remains unchanged.
+5. Coordinate emitted check names with repository rulesets as described below.
+
+## Required-check rename
+
+The emitted check name is now `UnderstandProof / understanding required`.
+Change the required status-check context from `SlopProof / understanding required`
+to that name, keeping the existing GitHub App identity and all other required
+checks unchanged. For the hosted repository, the App ID is `4570049`.
+
+The operator accepts that existing open PRs can wait for the new name during
+this cutover. Until the updated application is deployed, the running version
+still emits the old name. This is blocking, not an automatic pass. After
+deployment, verify a fresh PR revision reports the new check from the same App.
+Existing runs may retain the old name until the application next updates them;
+there is no historical evidence rewrite or database migration.
+
+A rollback to an older application also requires restoring the old required
+check context. Do not remove the required gate or change its App binding.

--- a/packages/db/src/github-check-intent.test.ts
+++ b/packages/db/src/github-check-intent.test.ts
@@ -9,7 +9,7 @@ const baseIntent: GithubCheckIntent = {
   expectedHeadSha: "a".repeat(40),
   idempotencyKey: "check:intent:review-required",
   reason: "review_required",
-  name: "SlopProof / understanding required",
+  name: "UnderstandProof / understanding required",
   status: "in_progress",
   conclusion: null,
   publicSummary: "maintainer review required for head",

--- a/packages/github/src/check-run.test.ts
+++ b/packages/github/src/check-run.test.ts
@@ -55,7 +55,7 @@ describe("OctokitCheckRunAdapter", () => {
       {
         owner: "acme",
         repositoryName: "cachekit",
-        name: GITHUB_CHECK_NAME,
+        name: "UnderstandProof / understanding required",
         headSha,
         detailsUrl: intent.detailsUrl,
         externalId: revisionId,
@@ -89,7 +89,7 @@ describe("OctokitCheckRunAdapter", () => {
       expect.objectContaining({
         checkRunId: 701,
         externalId: revisionId,
-        name: GITHUB_CHECK_NAME,
+        name: "UnderstandProof / understanding required",
       }),
       expect.any(AbortSignal),
     );

--- a/packages/github/src/production-ports.ts
+++ b/packages/github/src/production-ports.ts
@@ -322,6 +322,7 @@ export interface GithubUserAuthorizationPort {
   ): Promise<readonly string[]>;
 }
 
-// Compatibility identifier: repository rulesets require this exact check name.
+// Repository rulesets must require this exact name from the existing GitHub App.
 // See docs/operations/understandproof-rename.md before changing it.
-export const GITHUB_CHECK_NAME = "SlopProof / understanding required" as const;
+export const GITHUB_CHECK_NAME =
+  "UnderstandProof / understanding required" as const;

--- a/packages/github/src/service.ts
+++ b/packages/github/src/service.ts
@@ -192,8 +192,9 @@ export class FakeGithubCheckAdapter implements GithubCheckPort {
     await executor.query(
       `INSERT INTO check_runs
         (revision_id, github_check_run_id, name, status, conclusion, public_summary, details_url)
-       VALUES ($1, $2, 'SlopProof / understanding required', $3, $4, $5, $6)
+       VALUES ($1, $2, $7, $3, $4, $5, $6)
        ON CONFLICT (revision_id) DO UPDATE SET
+         name = EXCLUDED.name,
          status = EXCLUDED.status,
          conclusion = EXCLUDED.conclusion,
          public_summary = EXCLUDED.public_summary,
@@ -207,6 +208,7 @@ export class FakeGithubCheckAdapter implements GithubCheckPort {
         input.conclusion,
         input.summary,
         input.detailsUrl,
+        GITHUB_CHECK_NAME,
       ],
     );
   }

--- a/scripts/seed-demo.ts
+++ b/scripts/seed-demo.ts
@@ -364,7 +364,7 @@ try {
       `INSERT INTO check_runs
         (revision_id, github_check_run_id, name, status, conclusion,
          public_summary, details_url)
-       VALUES ($1, $2, 'SlopProof / understanding required', 'in_progress', NULL,
+       VALUES ($1, $2, 'UnderstandProof / understanding required', 'in_progress', NULL,
                $3, $4)
        ON CONFLICT (revision_id) DO NOTHING`,
       [

--- a/tests/integration/domain-db.integration.test.ts
+++ b/tests/integration/domain-db.integration.test.ts
@@ -595,7 +595,7 @@ databaseDescribe("PostgreSQL domain constraints", () => {
       connection.pool.query(
         `INSERT INTO check_runs
           (revision_id, github_check_run_id, name, status, conclusion, public_summary, details_url)
-         VALUES ($1, 'check-1', 'SlopProof / understanding required', 'completed', 'success',
+         VALUES ($1, 'check-1', 'UnderstandProof / understanding required', 'completed', 'success',
                  'passed', 'https://slopproof.test/revision')`,
         [ids.revision],
       ),

--- a/tests/integration/github-production-db.integration.test.ts
+++ b/tests/integration/github-production-db.integration.test.ts
@@ -2221,7 +2221,7 @@ function checkIntent(): GithubCheckIntent {
     expectedHeadSha: headSha,
     idempotencyKey: "check:intent:revision-1",
     reason: "webhook_ingested",
-    name: "SlopProof / understanding required",
+    name: "UnderstandProof / understanding required",
     status: "in_progress",
     conclusion: null,
     publicSummary: "understanding required for the current head",

--- a/tests/integration/provider-pipeline.integration.test.ts
+++ b/tests/integration/provider-pipeline.integration.test.ts
@@ -886,7 +886,7 @@ async function seedProviderAttempt(
         (id, revision_id, github_check_run_id, name, status, conclusion,
          public_summary, details_url, last_synchronized_at, created_at, updated_at)
        VALUES ($1, $2, 'provider-integration-check',
-               'SlopProof / understanding required', 'in_progress', NULL,
+               'UnderstandProof / understanding required', 'in_progress', NULL,
                'Proof processing is in progress.',
                'https://slopproof.test/provider-integration', $3, $3, $3)`,
       [ids.checkRun, ids.revision, new Date("2030-08-12T11:00:00.000Z")],


### PR DESCRIPTION
## Change

Rename the emitted GitHub check to `UnderstandProof / understanding required` across the production adapter, worker intents, demo and test fixtures. The fake adapter also refreshes the stored name on updates. Keep App identity, conclusions, authorization, SHA bindings and proof policy unchanged.

Update the operator documentation and assert the literal new name in existing create/update adapter tests. No historical screenshots, evidence or SQL migrations changed.

## Verification

- Full `pnpm verify` passed (unit tests, build and audits).
- PostgreSQL 18.4: four targeted integration suites, 63 tests passed (domain, production GitHub DB, provider pipeline, GitHub flow).
- `pnpm format:check` and `git diff --check` passed.

## Hosted cutover

At Pascal's explicit request, `Protect main` now requires the new name from the same App ID `4570049`. Every other ruleset field is unchanged and was verified by readback; the previous configuration is saved locally.

Production still runs the previous application release and emits the old name until this change is deployed. Existing PRs can remain blocked/Expected during this accepted transition; Pascal can use the existing operator bypass if necessary. This PR does not deploy the application or bypass any check. Rollback to an older emitter requires restoring the old required-check context as well.
